### PR TITLE
Quantity enhancements

### DIFF
--- a/AresScript.Tests/Program.cs
+++ b/AresScript.Tests/Program.cs
@@ -1549,6 +1549,34 @@ public class InterpreterTests
   }
 
   [Test]
+  public async Task Quantity_As_Extension_Works()
+  {
+    var script = """
+      converted = duration.as("ms")
+      assert converted.scalar == 1500
+      """;
+
+    await RunScriptWithEnvironmentAsync(
+      script,
+      env => env.AssignVariable("duration", AresValueHelper.CreateQuantity(UnitsNet.Duration.FromSeconds(1.5).ToQuantityValue())));
+  }
+
+  [Test]
+  public Task Validator_Rejects_Quantity_As_With_Incompatible_Unit()
+  {
+    var script = """duration.as("cm")""";
+
+    var ex = Assert.ThrowsAsync<AresInterpreterException>(() => ValidateScriptAsync(
+      script,
+      env => env.AssignVariable(
+        "duration",
+        AresValueHelper.CreateQuantity(UnitsNet.Duration.FromSeconds(1).ToQuantityValue()),
+        AresSchemaBuilder.Entry(AresDataType.Quantity).WithQuantity(QuantityType.Duration).Build())));
+    Assert.That(ex?.Message, Does.Contain("Unit 'cm' is not valid for quantity type 'Duration'."));
+    return Task.CompletedTask;
+  }
+
+  [Test]
   public async Task Empty_Array_Literal_Does_Not_Throw()
   {
     var script = """

--- a/AresScript.Tests/Program.cs
+++ b/AresScript.Tests/Program.cs
@@ -1577,6 +1577,19 @@ public class InterpreterTests
   }
 
   [Test]
+  public async Task Validation_Allows_Quantity_As_Chained_To_Scalar()
+  {
+    var script = """shmepis = bepis.as("f").scalar""";
+
+    await ValidateScriptAsync(
+      script,
+      env => env.AssignVariable(
+        "bepis",
+        AresValueHelper.CreateQuantity(UnitsNet.Temperature.FromDegreesCelsius(0).ToQuantityValue()),
+        AresSchemaBuilder.Entry(AresDataType.Quantity).WithQuantity(QuantityType.Temperature).Build()));
+  }
+
+  [Test]
   public async Task Empty_Array_Literal_Does_Not_Throw()
   {
     var script = """

--- a/AresScript/Environment/AresScriptEnvironment.cs
+++ b/AresScript/Environment/AresScriptEnvironment.cs
@@ -506,6 +506,9 @@ public class AresScriptEnvironment
       case AresDataType.Function:
         kind = AresValue.KindOneofCase.FunctionValue;
         return true;
+      case AresDataType.Quantity:
+        kind = AresValue.KindOneofCase.QuantityValue;
+        return true;
       default:
         kind = default;
         return false;

--- a/AresScript/Interpreters/AresBaseInterpreter.cs
+++ b/AresScript/Interpreters/AresBaseInterpreter.cs
@@ -689,22 +689,27 @@ public class AresBaseInterpreter : AresLangBaseVisitor<Task<AresValue>>
 
   public override async Task<AresValue> VisitMemberAccess([NotNull] AresLangParser.MemberAccessContext context)
   {
-    var structVal = await Visit(context.expression());
-    if(structVal.KindCase != AresValue.KindOneofCase.StructValue)
-    {
-      throw new AresInterpreterException(
-        $"Trying to access a member of a value that is not a struct. Value type: {structVal.KindCase}.",
-        context.Start.Line,
-        context.Start.Column
-      );
-    }
-
-    if(structVal.StructValue.Fields.TryGetValue(context.ID().GetText(), out var aresValue))
+    var varWithMember = await Visit(context.expression());
+    var id = context.ID().GetText();
+    if(varWithMember.KindCase == AresValue.KindOneofCase.StructValue
+       && varWithMember.StructValue.Fields.TryGetValue(id, out var aresValue))
     {
       return aresValue;
     }
 
-    return AresValueHelper.CreateNull();
+    if(varWithMember.KindCase == AresValue.KindOneofCase.QuantityValue)
+    {
+      if(nameof(varWithMember.QuantityValue.Scalar).Equals(id, StringComparison.OrdinalIgnoreCase))
+      {
+        return AresValueHelper.CreateNumber(varWithMember.QuantityValue.Scalar);
+      }
+    }
+    
+    throw new AresInterpreterException(
+      $"Trying to access a member of a value that has no members. Value type: {varWithMember.KindCase}.",
+      context.Start.Line,
+      context.Start.Column
+    );
   }
 
   public override async Task<AresValue> VisitIndexAccess([NotNull] AresLangParser.IndexAccessContext context)

--- a/AresScript/Interpreters/AresValidationInterpreter.cs
+++ b/AresScript/Interpreters/AresValidationInterpreter.cs
@@ -742,7 +742,7 @@ public sealed class AresValidationInterpreter : AresLangBaseVisitor<Task>
       var receiverSchema = _typeInference.Visit(memberCtx.expression());
       if(_environment.TryGetExtensionFunction(receiverSchema.Type, memberName, out var extensionFunc))
       {
-        ValidateExtensionFunctionArgs(extensionFunc, receiverSchema, positionalArgs, keywordArgs, ctx);
+        ValidateExtensionFunctionArgs(extensionFunc, memberCtx.expression(), receiverSchema, positionalArgs, keywordArgs, ctx);
         RecordFunctionInvocation(extensionFunc.Id, extensionFunc.Name, ctx, AresFunctionInvocationKind.Extension);
         return;
       }
@@ -1069,6 +1069,7 @@ public sealed class AresValidationInterpreter : AresLangBaseVisitor<Task>
 
   private void ValidateExtensionFunctionArgs(
     AresSystemFunctionSymbol function,
+    AresLangParser.ExpressionContext receiverExpression,
     AresValueSchema receiverSchema,
     IReadOnlyList<AresLangParser.ExpressionContext> positionalArgs,
     IReadOnlyDictionary<string, AresLangParser.ExpressionContext> keywordArgs,
@@ -1101,6 +1102,31 @@ public sealed class AresValidationInterpreter : AresLangBaseVisitor<Task>
 
     var trimmedSchema = TrimReceiverFromSchema(function.InputSchema);
     ValidateArgsAgainstSchema(function.Id, trimmedSchema, positionalArgs, keywordArgs, ctx);
+
+    if(function.StaticArgumentValidator is not null)
+    {
+      var validatorArgs = new List<AresLangParser.ExpressionContext>(positionalArgs.Count + 1) { receiverExpression };
+      validatorArgs.AddRange(positionalArgs);
+
+      var resolvedArgs = ResolveStaticValidatorArgs(function.InputSchema, validatorArgs, keywordArgs);
+      if(resolvedArgs.Length > 0 && resolvedArgs[0] is null)
+      {
+        resolvedArgs[0] = TryBuildAssignmentValue(receiverExpression) ?? DummyValueFactory.CreateDummyValue(receiverSchema);
+      }
+
+      var validation = function.StaticArgumentValidator(resolvedArgs);
+      if(!validation.Success)
+      {
+        var arg = validation.Index == 0
+          ? receiverExpression
+          : ResolveStaticValidatorErrorExpression(function.InputSchema, validatorArgs, keywordArgs, validation.Index);
+        throw new AresInterpreterException(
+          validation.Error ?? "",
+          arg?.Start.Line ?? ctx.Start.Line,
+          arg?.Start.Column ?? ctx.Start.Column
+        );
+      }
+    }
   }
 
   private void ValidateArgsAgainstSchema(

--- a/AresScript/Interpreters/AresValidationInterpreter.cs
+++ b/AresScript/Interpreters/AresValidationInterpreter.cs
@@ -617,6 +617,14 @@ public sealed class AresValidationInterpreter : AresLangBaseVisitor<Task>
       }
     }
 
+    if(value.KindCase == AresValue.KindOneofCase.QuantityValue)
+    {
+      if(nameof(value.QuantityValue.Scalar).Equals(id, StringComparison.OrdinalIgnoreCase))
+      {
+        return Task.CompletedTask;
+      }
+    }
+
     if(_environment.TryGetExtensionFunction(value, id, out _))
     {
       return Task.CompletedTask;

--- a/AresScript/Interpreters/AresValidationInterpreter.cs
+++ b/AresScript/Interpreters/AresValidationInterpreter.cs
@@ -1532,6 +1532,32 @@ public sealed class AresValidationInterpreter : AresLangBaseVisitor<Task>
   {
     value = null;
 
+    if(functionCall.expression() is AresLangParser.MemberAccessContext memberAccess)
+    {
+      var receiverSchema = _typeInference.Visit(memberAccess.expression());
+      if(_environment.TryGetExtensionFunction(receiverSchema.Type, memberAccess.ID().GetText(), out var extensionFunction))
+      {
+        var outputVal = DummyValueFactory.CreateDummyValue(extensionFunction.OutputSchema);
+
+        if(outputVal.QuantityValue is not null)
+        {
+          var (positionalArgs, keywordArgs) = ExtractFunctionCallArguments(functionCall);
+          var validatorArgs = new List<AresLangParser.ExpressionContext>(positionalArgs.Count + 1) { memberAccess.expression() };
+          validatorArgs.AddRange(positionalArgs);
+          var resolvedArgs = ResolveStaticValidatorArgs(extensionFunction.InputSchema, validatorArgs, keywordArgs);
+
+          var unitArg = resolvedArgs.ElementAtOrDefault(1);
+          if(unitArg?.HasStringValue == true)
+          {
+            outputVal.QuantityValue.Unit = unitArg.StringValue;
+          }
+        }
+
+        value = outputVal;
+        return true;
+      }
+    }
+
     var funcId = TryResolveFunctionId(functionCall.expression());
     if(funcId is null)
     {

--- a/AresScript/QuantityUnitHelper.cs
+++ b/AresScript/QuantityUnitHelper.cs
@@ -43,7 +43,11 @@ public static class QuantityUnitHelper
     return true;
   }
 
-  public static bool TryParseUnit(QuantityType quantityType, string unitText, out Enum? unit, out string? error)
+  public static bool TryParseUnit(
+    QuantityType quantityType,
+    string unitText,
+    [NotNullWhen(true)] out Enum? unit,
+    out string? error)
   {
     UnitsNetAbbreviationExtensions.EnsureRegistered();
 
@@ -115,13 +119,14 @@ public static class QuantityUnitHelper
       return false;
     }
 
-    scalar = valueArg.NumberValue;
-    if(!TryParseUnit(quantityType, unitArg.StringValue, out unit, out var parseError))
+    if(!TryParseUnit(quantityType, unitArg.StringValue, out var parsedUnit, out var parseError))
     {
       error = parseError;
       return false;
     }
 
+    scalar = valueArg.NumberValue;
+    unit = parsedUnit;
     return true;
   }
 

--- a/AresScript/ScriptAnalysis/AresScriptAnalysis.Completions.cs
+++ b/AresScript/ScriptAnalysis/AresScriptAnalysis.Completions.cs
@@ -1,5 +1,6 @@
 using Antlr4.Runtime;
 using Ares.Datamodel;
+using Ares.Datamodel.Extensions;
 using Ares.Datamodel.Scripting;
 using AresScript.Environment;
 using AresScript.Generated;
@@ -70,10 +71,12 @@ public static partial class AresScriptAnalysis
           AddCompletionForAresValue(items, environment, field.Key, field.Value, parentIdentifier);
         }
 
+        AddQuantityCompletions(items, parentValue, parentIdentifier);
         AddExtensionCompletions(items, environment, parentValue, parentIdentifier);
       }
       else if(TryResolveValue(environment, parentIdentifier, out var plainValue))
       {
+        AddQuantityCompletions(items, plainValue, parentIdentifier);
         AddExtensionCompletions(items, environment, plainValue, parentIdentifier);
       }
     }
@@ -291,6 +294,34 @@ public static partial class AresScriptAnalysis
           parentIdentifier: parentIdentifier)
       });
     }
+  }
+
+  private static void AddQuantityCompletions(
+    ICollection<CompletionItem> items,
+    AresValue parentValue,
+    string parentIdentifier)
+  {
+    if(parentValue.KindCase != AresValue.KindOneofCase.QuantityValue)
+    {
+      return;
+    }
+
+    items.Add(new CompletionItem
+    {
+      Label = nameof(parentValue.QuantityValue.Scalar).ToLowerInvariant(),
+      InsertText = nameof(parentValue.QuantityValue.Scalar).ToLowerInvariant(),
+      Metadata = ScriptSymbolMetadataMapper.ToMetadata(
+        new AresScriptValueSymbol(
+          Name: nameof(parentValue.QuantityValue.Scalar).ToLowerInvariant(),
+          Value: AresValueHelper.CreateNumber(parentValue.QuantityValue.Scalar),
+          IsReadOnly: true,
+          SymbolKind: SymbolKind.Variable,
+          Detail: "Quantity scalar",
+          Documentation: "Returns the numeric scalar component of the quantity.",
+          ParentName: parentIdentifier),
+        parentIdentifier: parentIdentifier,
+        valueSchema: new AresValueSchema { Type = AresDataType.Number })
+    });
   }
 
   // First argument is always 'self' so we don't need that for validation

--- a/AresScript/StandardLibrary.cs
+++ b/AresScript/StandardLibrary.cs
@@ -3,6 +3,7 @@ using Ares.Datamodel.Extensions;
 using Ares.Datamodel.Factories;
 using AresScript.Symbols;
 using System.Text;
+using UnitsNet;
 using UnitsNet.Units;
 
 namespace AresScript;
@@ -182,6 +183,80 @@ public static class StandardLibrary
   public static AresExtensionFunction[] ExtensionFunctions { get; } =
   [
     new(
+      AresValue.KindOneofCase.QuantityValue,
+      "as",
+      new AresSystemFunctionSymbol(
+        "quantity::as",
+        "as",
+        (args, _) =>
+        {
+          if(args.Count != 2)
+          {
+            throw new ArgumentException("Expected exactly 1 argument to as.", nameof(args));
+          }
+
+          var quantityValue = args[0];
+          if(quantityValue.KindCase != AresValue.KindOneofCase.QuantityValue
+            || !quantityValue.QuantityValue.TryToUnitsNetQuantity(out var quantity)
+            || quantity is null)
+          {
+            throw new InvalidOperationException("as can only be called on quantity values.");
+          }
+
+          if(args[1] is not { HasStringValue: true } unitArg || string.IsNullOrWhiteSpace(unitArg.StringValue))
+          {
+            throw new InvalidOperationException("as requires a non-empty unit string.");
+          }
+
+          if(!TryResolveQuantityType(quantity, out var quantityType, out var quantityTypeError))
+          {
+            throw new InvalidOperationException(quantityTypeError);
+          }
+
+          if(!QuantityUnitHelper.TryParseUnit(quantityType, unitArg.StringValue, out var unit, out var error))
+          {
+            throw new InvalidOperationException(error);
+          }
+
+          return Task.FromResult(AresValueHelper.CreateQuantity(Quantity.From(quantity.As(unit), unit).ToQuantityValue()));
+        },
+        BuildQuantityAsSchema(),
+        AresSchemaBuilder.Entry(AresDataType.Quantity).Build(),
+        Namespace: "",
+        IsExtension: true
+      )
+      {
+        Detail = "Convert a quantity to a different compatible unit.",
+        Documentation = "Converts a quantity to another compatible unit string, for example duration.as(\"ms\").",
+        StaticArgumentValidator = args =>
+        {
+          if(args.Count != 2 || args[0] is null || args[1] is not { HasStringValue: true } unitArg || string.IsNullOrWhiteSpace(unitArg.StringValue))
+          {
+            return new StaticArgValidation(true);
+          }
+
+          var receiver = args[0]!;
+          if(receiver.KindCase != AresValue.KindOneofCase.QuantityValue
+            || !receiver.QuantityValue.TryToUnitsNetQuantity(out var quantity)
+            || quantity is null)
+          {
+            return new StaticArgValidation(false, "as can only be called on quantity values.", 0);
+          }
+
+          if(!TryResolveQuantityType(quantity, out var quantityType, out var quantityTypeError))
+          {
+            return new StaticArgValidation(false, quantityTypeError, 0);
+          }
+
+          if(!QuantityUnitHelper.TryParseUnit(quantityType, unitArg.StringValue, out _, out var error))
+          {
+            return new StaticArgValidation(false, error, 1);
+          }
+
+          return new StaticArgValidation(true);
+        }
+      }),
+    new(
       AresValue.KindOneofCase.ListValue,
       "append",
       new AresSystemFunctionSymbol(
@@ -297,6 +372,14 @@ public static class StandardLibrary
       .Build();
   }
 
+  private static AresStructSchema BuildQuantityAsSchema()
+  {
+    return AresSchemaBuilder.Empty()
+      .AddEntry("self", AresSchemaBuilder.Entry(AresDataType.Quantity).Build())
+      .AddEntry("unit", AresSchemaBuilder.Entry(AresDataType.String).Build())
+      .Build();
+  }
+
   private static AresStructSchema BuildNumberArrayAppendSchema()
   {
     return AresSchemaBuilder.Empty()
@@ -333,5 +416,19 @@ public static class StandardLibrary
     }
 
     return quantity.As(DurationUnit.Millisecond);
+  }
+
+  private static bool TryResolveQuantityType(IQuantity quantity, out QuantityType quantityType, out string? error)
+  {
+    error = null;
+    if(Enum.TryParse<QuantityType>(quantity.QuantityInfo.Name, true, out quantityType)
+      && quantityType != QuantityType.Unspecified)
+    {
+      return true;
+    }
+
+    quantityType = QuantityType.Unspecified;
+    error = $"Unsupported quantity type '{quantity.QuantityInfo.Name}'.";
+    return false;
   }
 }


### PR DESCRIPTION
Added a member "scalar" to the quantity values in order to get just the numerical value of a quantity.
Added an "as(...)" extension to quantity values in order to support changing between various unit types. Ex.: Quantity.Duration.from(100,"ms").as("s").