### PR TITLE
Campaign data export

### DIFF
--- a/Ares.Core.Tests/DataManagement/DataMappers/AresValueFlattenerTests.cs
+++ b/Ares.Core.Tests/DataManagement/DataMappers/AresValueFlattenerTests.cs
@@ -1,0 +1,43 @@
+using Ares.Core.DataManagement.DataMappers;
+using Ares.Datamodel.Extensions;
+
+namespace Ares.Core.Tests.DataManagement.DataMappers;
+
+internal class AresValueFlattenerTests
+{
+  [Test]
+  public void Flatten_ReturnsScalarWithOriginalName()
+  {
+    var flattened = AresValueFlattener.Flatten("Value", AresValueHelper.CreateNumber(1)).Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(flattened.Key, Is.EqualTo("Value"));
+      Assert.That(flattened.Value.NumberValue, Is.EqualTo(1));
+    }
+  }
+
+  [Test]
+  public void Flatten_RecursivelyFlattensNestedStructs()
+  {
+    var value = AresValueHelper.CreateStruct();
+    value.StructValue.Fields["Nested"] = AresValueHelper.CreateStruct();
+    value.StructValue.Fields["Nested"].StructValue.Fields["Value"] = AresValueHelper.CreateString("result");
+
+    var flattened = AresValueFlattener.Flatten("Root", value).Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(flattened.Key, Is.EqualTo("Root.Nested.Value"));
+      Assert.That(flattened.Value.StringValue, Is.EqualTo("result"));
+    }
+  }
+
+  [Test]
+  public void Flatten_ReturnsNoValuesForEmptyStruct()
+  {
+    var flattened = AresValueFlattener.Flatten("Root", AresValueHelper.CreateStruct());
+
+    Assert.That(flattened, Is.Empty);
+  }
+}

--- a/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
+++ b/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
@@ -35,21 +35,18 @@ internal class CampaignDatasetGeneratorTests
       CreateExperiment(firstStart, firstEnd, analysisResult: 1.5));
     var generator = CreateGenerator(summary);
 
-    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Experiments");
 
     using(Assert.EnterMultipleScope())
     {
       Assert.That(dataset.Name, Is.EqualTo("Experiments"));
-      Assert.That(dataset.Columns.Take(9).Select(column => column.Name), Is.EqualTo([
+      Assert.That(dataset.Columns.Take(6).Select(column => column.Name), Is.EqualTo([
         "Experiment Number",
-        "Experiment Execution ID",
-        "Experiment ID",
         "Experiment Template",
         "Time Started",
         "Time Finished",
         "Duration Seconds",
-        "Analysis Result",
-        "Result Output Path"
+        "Analysis Result"
       ]));
       Assert.That(ColumnSchema(dataset, "Experiment Number").Type, Is.EqualTo(AresDataType.Int));
       Assert.That(ColumnSchema(dataset, "Time Started").Type, Is.EqualTo(AresDataType.Timestamp));
@@ -87,7 +84,7 @@ internal class CampaignDatasetGeneratorTests
       ]));
     var generator = CreateGenerator(summary);
 
-    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Experiments");
     original.StringValue = "after";
 
     using(Assert.EnterMultipleScope())
@@ -106,24 +103,16 @@ internal class CampaignDatasetGeneratorTests
   }
 
   [Test]
-  public async Task GenerateAsync_IncludesExperimentIdentityTemplateAndOutputPath()
+  public async Task GenerateAsync_IncludesExperimentTemplate()
   {
     var summaryId = Guid.NewGuid().ToString();
     var experiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1));
-    experiment.ExperimentId = "experiment-id";
     experiment.ExperimentOverview.Template = new ExperimentTemplate { Name = "Template A" };
-    experiment.ResultOutputPath = "results/experiment.json";
     var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment));
 
-    var row = (await generator.GenerateAsync(summaryId)).Single().Rows.Single();
+    var row = GetDataset(await generator.GenerateAsync(summaryId), "Experiments").Rows.Single();
 
-    using(Assert.EnterMultipleScope())
-    {
-      Assert.That(row.Data.Fields["Experiment Execution ID"].StringValue, Is.EqualTo(experiment.UniqueId));
-      Assert.That(row.Data.Fields["Experiment ID"].StringValue, Is.EqualTo("experiment-id"));
-      Assert.That(row.Data.Fields["Experiment Template"].StringValue, Is.EqualTo("Template A"));
-      Assert.That(row.Data.Fields["Result Output Path"].StringValue, Is.EqualTo("results/experiment.json"));
-    }
+    Assert.That(row.Data.Fields["Experiment Template"].StringValue, Is.EqualTo("Template A"));
   }
 
   [Test]
@@ -144,7 +133,7 @@ internal class CampaignDatasetGeneratorTests
         resultFields: [("Metrics", result)],
         parameters: [CreateParameter("Temperatures", parameter)])));
 
-    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Experiments");
 
     using(Assert.EnterMultipleScope())
     {
@@ -165,7 +154,7 @@ internal class CampaignDatasetGeneratorTests
       CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), resultFields: [("Value", AresValueHelper.CreateNumber(1))]),
       CreateExperiment(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), resultFields: [("Value", AresValueHelper.CreateString("one"))])));
 
-    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Experiments");
 
     Assert.That(ColumnSchema(dataset, "Output.Value").Type, Is.EqualTo(AresDataType.Any));
   }
@@ -182,9 +171,192 @@ internal class CampaignDatasetGeneratorTests
     summary.CloseoutExecutionSummary = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1));
     var generator = CreateGenerator(summary);
 
-    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Experiments");
 
     Assert.That(dataset.Rows, Has.Count.EqualTo(1));
+  }
+
+  [Test]
+  public async Task GenerateAsync_ReturnsExperimentsAndCommandsDatasets()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var generator = CreateGenerator(CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1))));
+
+    var datasets = await generator.GenerateAsync(summaryId);
+
+    Assert.That(datasets.Select(dataset => dataset.Name), Is.EqualTo(["Experiments", "Commands"]));
+  }
+
+  [Test]
+  public async Task GenerateAsync_CreatesCommandRowsAndFixedColumns()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var commandStart = DateTime.UnixEpoch.AddSeconds(12);
+    var commandEnd = DateTime.UnixEpoch.AddSeconds(15);
+    var command = CreateCommand(
+      commandStart,
+      commandEnd,
+      commandName: "Aspirate",
+      commandDescription: "Move liquid",
+      statusCode: CommandStatusCode.CommandSuccess,
+      result: new CommandResult
+      {
+        Success = true,
+        Result = AresValueHelper.CreateNumber(10),
+        StatusCode = CommandStatusCode.CommandFailed,
+        Error = "warning"
+      });
+    var step = CreateStep("step-id", DateTime.UnixEpoch.AddSeconds(11), DateTime.UnixEpoch.AddSeconds(16), command);
+    var experiment = CreateExperiment(DateTime.UnixEpoch.AddSeconds(10), DateTime.UnixEpoch.AddSeconds(20), steps: [step]);
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+    var row = dataset.Rows.Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Columns.Take(12).Select(column => column.Name), Is.EqualTo([
+        "Experiment Number",
+        "Step Number",
+        "Command Number",
+        "Command Name",
+        "Command Description",
+        "Time Started",
+        "Time Finished",
+        "Duration Seconds",
+        "Status",
+        "Success",
+        "Error",
+        "Output"
+      ]));
+      Assert.That(ColumnSchema(dataset, "Experiment Number").Type, Is.EqualTo(AresDataType.Int));
+      Assert.That(ColumnSchema(dataset, "Step Number").Type, Is.EqualTo(AresDataType.Int));
+      Assert.That(ColumnSchema(dataset, "Command Number").Type, Is.EqualTo(AresDataType.Int));
+      Assert.That(ColumnSchema(dataset, "Status").Type, Is.EqualTo(AresDataType.String));
+      Assert.That(ColumnSchema(dataset, "Success").Type, Is.EqualTo(AresDataType.Boolean));
+      Assert.That(row.Data.Fields["Experiment Number"].IntValue, Is.EqualTo(1));
+      Assert.That(row.Data.Fields["Step Number"].IntValue, Is.EqualTo(1));
+      Assert.That(row.Data.Fields["Command Number"].IntValue, Is.EqualTo(1));
+      Assert.That(row.Data.Fields["Command Name"].StringValue, Is.EqualTo("Aspirate"));
+      Assert.That(row.Data.Fields["Command Description"].StringValue, Is.EqualTo("Move liquid"));
+      Assert.That(row.Data.Fields["Time Started"].TimestampValue, Is.EqualTo(Timestamp.FromDateTime(commandStart)));
+      Assert.That(row.Data.Fields["Time Finished"].TimestampValue, Is.EqualTo(Timestamp.FromDateTime(commandEnd)));
+      Assert.That(row.Data.Fields["Duration Seconds"].NumberValue, Is.EqualTo(3));
+      Assert.That(row.Data.Fields["Status"].StringValue, Is.EqualTo(CommandStatusCode.CommandSuccess.ToString()));
+      Assert.That(row.Data.Fields["Success"].BoolValue, Is.True);
+      Assert.That(row.Data.Fields["Error"].StringValue, Is.EqualTo("warning"));
+      Assert.That(row.Data.Fields["Output"].NumberValue, Is.EqualTo(10));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_SortsCommandRowsByExperimentStepAndCommandTime()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var firstCommand = CreateCommand(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), commandName: "First");
+    var secondCommand = CreateCommand(DateTime.UnixEpoch.AddSeconds(4), DateTime.UnixEpoch.AddSeconds(5), commandName: "Second");
+    var firstStep = CreateStep("first-step", DateTime.UnixEpoch.AddSeconds(1), DateTime.UnixEpoch.AddSeconds(6), secondCommand, firstCommand);
+    var secondStep = CreateStep("second-step", DateTime.UnixEpoch.AddSeconds(7), DateTime.UnixEpoch.AddSeconds(8), CreateCommand(DateTime.UnixEpoch.AddSeconds(7), DateTime.UnixEpoch.AddSeconds(8), commandName: "Third"));
+    var laterExperiment = CreateExperiment(DateTime.UnixEpoch.AddSeconds(20), DateTime.UnixEpoch.AddSeconds(21), steps: [
+      CreateStep("later-step", DateTime.UnixEpoch.AddSeconds(20), DateTime.UnixEpoch.AddSeconds(21), CreateCommand(DateTime.UnixEpoch.AddSeconds(20), DateTime.UnixEpoch.AddSeconds(21), commandName: "Fourth"))
+    ]);
+    var earlierExperiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(10), steps: [secondStep, firstStep]);
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", laterExperiment, earlierExperiment));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    Assert.That(dataset.Rows.Select(row => row.Data.Fields["Command Name"].StringValue), Is.EqualTo(["First", "Second", "Third", "Fourth"]));
+  }
+
+  [Test]
+  public async Task GenerateAsync_FlattensStructCommandOutputs()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var output = AresValueHelper.CreateStruct();
+    output.StructValue.Fields["Measurement"] = AresValueHelper.CreateStruct();
+    output.StructValue.Fields["Measurement"].StructValue.Fields["Mass"] = AresValueHelper.CreateQuantity(4.5, QuantityType.Mass, "g");
+    var command = CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), result: new CommandResult { Result = output });
+    var generator = CreateGenerator(CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(2), steps: [CreateStep("step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(2), command)])));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Columns.Select(column => column.Name), Does.Contain("Output.Measurement.Mass"));
+      Assert.That(dataset.Rows.Single().Data.Fields["Output.Measurement.Mass"].QuantityValue.Scalar, Is.EqualTo(4.5));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_UsesAnySchemaForConflictingCommandOutputTypes()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var generator = CreateGenerator(CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(4), steps: [
+        CreateStep(
+          "step",
+          DateTime.UnixEpoch,
+          DateTime.UnixEpoch.AddSeconds(4),
+          CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), result: new CommandResult { Result = AresValueHelper.CreateNumber(1) }),
+          CreateCommand(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), result: new CommandResult { Result = AresValueHelper.CreateString("one") }))
+      ])));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    Assert.That(ColumnSchema(dataset, "Output").Type, Is.EqualTo(AresDataType.Any));
+  }
+
+  [Test]
+  public async Task GenerateAsync_LeavesCommandOutputColumnsEmptyWhenResultIsMissing()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var commandWithoutResult = CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), result: null);
+    var commandWithResult = CreateCommand(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), result: new CommandResult { Result = AresValueHelper.CreateNumber(2) });
+    var generator = CreateGenerator(CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(4), steps: [
+        CreateStep("step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(4), commandWithoutResult, commandWithResult)
+      ])));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Rows[0].Data.Fields.ContainsKey("Output"), Is.False);
+      Assert.That(dataset.Rows[1].Data.Fields["Output"].NumberValue, Is.EqualTo(2));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_ExcludesStartupAndCloseoutCommands()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var summary = CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), steps: [
+        CreateStep("experiment-step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), commandName: "Experiment"))
+      ]));
+    summary.StartupExecutionSummary = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), steps: [
+      CreateStep("startup-step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), commandName: "Startup"))
+    ]);
+    summary.CloseoutExecutionSummary = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), steps: [
+      CreateStep("closeout-step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), commandName: "Closeout"))
+    ]);
+    var generator = CreateGenerator(summary);
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    Assert.That(dataset.Rows.Select(row => row.Data.Fields["Command Name"].StringValue), Is.EqualTo(["Experiment"]));
   }
 
   [Test]
@@ -205,7 +377,7 @@ internal class CampaignDatasetGeneratorTests
         ]));
     var generator = CreateGenerator(summary);
 
-    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Experiments");
 
     using(Assert.EnterMultipleScope())
     {
@@ -263,6 +435,11 @@ internal class CampaignDatasetGeneratorTests
     return dataset.Columns.Single(column => column.Name == columnName).Schema;
   }
 
+  private static AresDataset GetDataset(IEnumerable<AresDataset> datasets, string name)
+  {
+    return datasets.Single(dataset => dataset.Name == name);
+  }
+
   private static CampaignExecutionSummary CreateCampaignSummary(
     string uniqueId,
     string campaignName,
@@ -288,7 +465,8 @@ internal class CampaignDatasetGeneratorTests
     DateTime timeFinished,
     double? analysisResult = null,
     (string Name, AresValue Value)[] resultFields = null,
-    Parameter[] parameters = null)
+    Parameter[] parameters = null,
+    StepExecutionSummary[] steps = null)
   {
     var overview = new ExperimentOverview
     {
@@ -305,7 +483,7 @@ internal class CampaignDatasetGeneratorTests
 
     overview.Parameters.AddRange(parameters ?? []);
 
-    return new ExperimentExecutionSummary
+    var experiment = new ExperimentExecutionSummary
     {
       UniqueId = Guid.NewGuid().ToString(),
       ExecutionInfo = new ExecutionInfo
@@ -315,6 +493,53 @@ internal class CampaignDatasetGeneratorTests
       },
       ExperimentOverview = overview
     };
+    experiment.StepSummaries.AddRange(steps ?? []);
+    return experiment;
+  }
+
+  private static StepExecutionSummary CreateStep(
+    string stepId,
+    DateTime timeStarted,
+    DateTime timeFinished,
+    params CommandExecutionSummary[] commands)
+  {
+    var step = new StepExecutionSummary
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      StepId = stepId,
+      ExecutionInfo = new ExecutionInfo
+      {
+        TimeStarted = Timestamp.FromDateTime(timeStarted),
+        TimeFinished = Timestamp.FromDateTime(timeFinished)
+      }
+    };
+    step.CommandSummaries.AddRange(commands);
+    return step;
+  }
+
+  private static CommandExecutionSummary CreateCommand(
+    DateTime timeStarted,
+    DateTime timeFinished,
+    string commandName = "",
+    string commandDescription = "",
+    CommandStatusCode statusCode = CommandStatusCode.StatusUnspecified,
+    CommandResult result = null)
+  {
+    var command = new CommandExecutionSummary
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      CommandName = commandName,
+      CommandDescription = commandDescription,
+      StatusCode = statusCode,
+      Result = result,
+      ExecutionInfo = new ExecutionInfo
+      {
+        TimeStarted = Timestamp.FromDateTime(timeStarted),
+        TimeFinished = Timestamp.FromDateTime(timeFinished)
+      }
+    };
+
+    return command;
   }
 
   private static Parameter CreateParameter(string metadataName, AresValue value, string uniqueId = "", long index = 0)

--- a/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
+++ b/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
@@ -1,6 +1,9 @@
 using Ares.Core.DataManagement.DataMappers;
 using Ares.Datamodel;
+using Ares.Datamodel.Analyzing;
+using Ares.Datamodel.Analyzing.Remote;
 using Ares.Datamodel.Extensions;
+using Ares.Datamodel.Planning;
 using Ares.Datamodel.Templates;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.EntityFrameworkCore;
@@ -177,7 +180,7 @@ internal class CampaignDatasetGeneratorTests
   }
 
   [Test]
-  public async Task GenerateAsync_ReturnsExperimentsAndCommandsDatasets()
+  public async Task GenerateAsync_ReturnsAllCampaignDatasets()
   {
     var summaryId = Guid.NewGuid().ToString();
     var generator = CreateGenerator(CreateCampaignSummary(
@@ -187,7 +190,17 @@ internal class CampaignDatasetGeneratorTests
 
     var datasets = await generator.GenerateAsync(summaryId);
 
-    Assert.That(datasets.Select(dataset => dataset.Name), Is.EqualTo(["Experiments", "Commands"]));
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(datasets.Select(dataset => dataset.Name), Is.EqualTo([
+        "Experiments",
+        "Commands",
+        "Planner Transactions",
+        "Analyzer Transactions"
+      ]));
+      Assert.That(GetDataset(datasets, "Planner Transactions").Rows, Is.Empty);
+      Assert.That(GetDataset(datasets, "Analyzer Transactions").Rows, Is.Empty);
+    }
   }
 
   [Test]
@@ -390,6 +403,142 @@ internal class CampaignDatasetGeneratorTests
   }
 
   [Test]
+  public async Task GenerateAsync_CreatesPlannerTransactionRows()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var experiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(5));
+    var nestedOutput = AresValueHelper.CreateStruct();
+    nestedOutput.StructValue.Fields["Value"] = AresValueHelper.CreateNumber(12.5);
+    var transaction = CreatePlannerTransaction(
+      experiment.ExperimentId,
+      DateTime.UnixEpoch.AddSeconds(1),
+      DateTime.UnixEpoch.AddSeconds(3),
+      ("Temperature", nestedOutput));
+    transaction.PlanningRequest.AnalysisResults.AddRange([1.5, 2.5]);
+    transaction.PlanningResponse.PlanningOutcome = Outcome.Warning;
+    transaction.PlanningResponse.ErrorString = "planner warning";
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment), [transaction]);
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Planner Transactions");
+    var row = dataset.Rows.Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Columns.Take(11).Select(column => column.Name), Is.EqualTo([
+        "Experiment Number",
+        "Planner Name",
+        "Planner Type",
+        "Planner Version",
+        "Time Request Sent",
+        "Time Response Received",
+        "Duration Seconds",
+        "Outcome",
+        "Error",
+        "Analysis Results",
+        "Output.Temperature.Value"
+      ]));
+      Assert.That(row.Data.Fields["Experiment Number"].IntValue, Is.EqualTo(1));
+      Assert.That(row.Data.Fields["Planner Name"].StringValue, Is.EqualTo("Planner A"));
+      Assert.That(row.Data.Fields["Duration Seconds"].NumberValue, Is.EqualTo(2));
+      Assert.That(row.Data.Fields["Outcome"].StringValue, Is.EqualTo(Outcome.Warning.ToString()));
+      Assert.That(row.Data.Fields["Error"].StringValue, Is.EqualTo("planner warning"));
+      Assert.That(row.Data.Fields["Analysis Results"].ListValue.Values.Select(value => value.NumberValue), Is.EqualTo([1.5, 2.5]));
+      Assert.That(row.Data.Fields["Output.Temperature.Value"].NumberValue, Is.EqualTo(12.5));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_CreatesAnalyzerTransactionRows()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var experiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(5));
+    var nestedInput = AresValueHelper.CreateStruct();
+    nestedInput.StructValue.Fields["Mass"] = AresValueHelper.CreateQuantity(4.5, QuantityType.Mass, "g");
+    var transaction = CreateAnalyzerTransaction(
+      experiment.ExperimentId,
+      DateTime.UnixEpoch.AddSeconds(2),
+      DateTime.UnixEpoch.AddSeconds(4),
+      ("Measurement", nestedInput));
+    transaction.AnalysisResponse = new Analysis
+    {
+      Result = 9.5f,
+      AnalysisOutcome = Outcome.Success,
+      ErrorString = "analysis note"
+    };
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment), analyzerTransactions: [transaction]);
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Analyzer Transactions");
+    var row = dataset.Rows.Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Columns.Take(11).Select(column => column.Name), Is.EqualTo([
+        "Experiment Number",
+        "Analyzer Name",
+        "Analyzer Type",
+        "Analyzer Version",
+        "Time Request Sent",
+        "Time Response Received",
+        "Duration Seconds",
+        "Result",
+        "Outcome",
+        "Error",
+        "Input.Measurement.Mass"
+      ]));
+      Assert.That(row.Data.Fields["Analyzer Version"].StringValue, Is.EqualTo("2.0"));
+      Assert.That(row.Data.Fields["Duration Seconds"].NumberValue, Is.EqualTo(2));
+      Assert.That(row.Data.Fields["Result"].NumberValue, Is.EqualTo(9.5));
+      Assert.That(row.Data.Fields["Outcome"].StringValue, Is.EqualTo(Outcome.Success.ToString()));
+      Assert.That(row.Data.Fields["Input.Measurement.Mass"].QuantityValue.Scalar, Is.EqualTo(4.5));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_FiltersTransactionsToMatchedCampaignExperimentsAndWindow()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var experiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(5));
+    var valid = CreatePlannerTransaction(experiment.ExperimentId, DateTime.UnixEpoch.AddSeconds(1), DateTime.UnixEpoch.AddSeconds(2));
+    var wrongCampaign = CreatePlannerTransaction(experiment.ExperimentId, DateTime.UnixEpoch.AddSeconds(1), DateTime.UnixEpoch.AddSeconds(2));
+    wrongCampaign.PlanningRequest.Metadata.CampaignId = "other-campaign";
+    var wrongExperiment = CreatePlannerTransaction("other-experiment", DateTime.UnixEpoch.AddSeconds(1), DateTime.UnixEpoch.AddSeconds(2));
+    var outsideWindow = CreatePlannerTransaction(experiment.ExperimentId, DateTime.UnixEpoch.AddSeconds(9), DateTime.UnixEpoch.AddSeconds(11));
+    var generator = CreateGenerator(
+      CreateCampaignSummary(summaryId, "Campaign A", experiment),
+      [valid, wrongCampaign, wrongExperiment, outsideWindow]);
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Planner Transactions");
+
+    Assert.That(dataset.Rows, Has.Count.EqualTo(1));
+  }
+
+  [Test]
+  public async Task GenerateAsync_UsesAnySchemaForConflictingTransactionValues()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var experiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(5));
+    var first = CreatePlannerTransaction(
+      experiment.ExperimentId,
+      DateTime.UnixEpoch.AddSeconds(1),
+      DateTime.UnixEpoch.AddSeconds(2),
+      ("Value", AresValueHelper.CreateNumber(1)));
+    var second = CreatePlannerTransaction(
+      experiment.ExperimentId,
+      DateTime.UnixEpoch.AddSeconds(3),
+      DateTime.UnixEpoch.AddSeconds(4),
+      ("Value", AresValueHelper.CreateString("one")));
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment), [first, second]);
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Planner Transactions");
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(ColumnSchema(dataset, "Output.Value").Type, Is.EqualTo(AresDataType.Any));
+      Assert.That(ColumnSchema(dataset, "Output.Value").Optional, Is.True);
+    }
+  }
+
+  [Test]
   public void GenerateAsync_ThrowsWhenAlreadyCanceled()
   {
     var contextFactory = CreateContextFactory();
@@ -401,12 +550,17 @@ internal class CampaignDatasetGeneratorTests
     contextFactory.Verify(factory => factory.CreateDbContextAsync(It.IsAny<CancellationToken>()), Times.Never);
   }
 
-  private static CampaignDatasetGenerator CreateGenerator(CampaignExecutionSummary summary)
+  private static CampaignDatasetGenerator CreateGenerator(
+    CampaignExecutionSummary summary,
+    PlannerTransaction[] plannerTransactions = null,
+    AnalyzerTransaction[] analyzerTransactions = null)
   {
     var options = CreateContextOptions();
     using(var context = new CoreDatabaseContext(options))
     {
       context.CampaignExecutionSummaries.Add(summary);
+      context.PlannerTransactions.AddRange(plannerTransactions ?? []);
+      context.AnalyzerTransactions.AddRange(analyzerTransactions ?? []);
       context.SaveChanges();
     }
 
@@ -486,6 +640,7 @@ internal class CampaignDatasetGeneratorTests
     var experiment = new ExperimentExecutionSummary
     {
       UniqueId = Guid.NewGuid().ToString(),
+      ExperimentId = Guid.NewGuid().ToString(),
       ExecutionInfo = new ExecutionInfo
       {
         TimeStarted = Timestamp.FromDateTime(timeStarted),
@@ -556,5 +711,72 @@ internal class CampaignDatasetGeneratorTests
     parameter.SetLiteralSource(value);
 
     return parameter;
+  }
+
+  private static PlannerTransaction CreatePlannerTransaction(
+    string experimentId,
+    DateTime requestSent,
+    DateTime responseReceived,
+    params (string Name, AresValue Value)[] outputs)
+  {
+    var transaction = new PlannerTransaction
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      PlannerName = "Planner A",
+      PlannerType = "Remote",
+      PlannerVersion = "1.0",
+      TimeRequestSent = Timestamp.FromDateTime(requestSent),
+      TimeResponseReceived = Timestamp.FromDateTime(responseReceived),
+      PlanningRequest = new PlanningRequest
+      {
+        Metadata = new RequestMetadata
+        {
+          CampaignId = "campaign-id",
+          ExperimentId = experimentId
+        }
+      },
+      PlanningResponse = new PlanningResponse()
+    };
+
+    transaction.PlanningResponse.PlannedParameters.AddRange(outputs.Select(output => new PlannedParameter
+    {
+      ParameterName = output.Name,
+      ParameterValue = output.Value
+    }));
+    return transaction;
+  }
+
+  private static AnalyzerTransaction CreateAnalyzerTransaction(
+    string experimentId,
+    DateTime requestSent,
+    DateTime responseReceived,
+    params (string Name, AresValue Value)[] inputs)
+  {
+    var transaction = new AnalyzerTransaction
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      AnalyzerName = "Analyzer A",
+      AnalyzerType = "Remote",
+      AnalyzerVersion = "2.0",
+      TimeRequestSent = Timestamp.FromDateTime(requestSent),
+      TimeResponseReceived = Timestamp.FromDateTime(responseReceived),
+      AnalysisRequest = new AnalysisRequest
+      {
+        Inputs = new AresStruct(),
+        Metadata = new RequestMetadata
+        {
+          CampaignId = "campaign-id",
+          ExperimentId = experimentId
+        }
+      },
+      AnalysisResponse = new Analysis()
+    };
+
+    foreach(var input in inputs)
+    {
+      transaction.AnalysisRequest.Inputs.Fields[input.Name] = input.Value;
+    }
+
+    return transaction;
   }
 }

--- a/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
+++ b/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
@@ -350,6 +350,107 @@ internal class CampaignDatasetGeneratorTests
   }
 
   [Test]
+  public async Task GenerateAsync_IncludesResolvedCommandInputsBeforeOutputs()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var structValue = AresValueHelper.CreateStruct();
+    structValue.StructValue.Fields["Temperature"] = AresValueHelper.CreateNumber(22.5);
+    var literal = CreateParameter("Literal", AresValueHelper.CreateString("literal"));
+    var planned = CreateParameter("Planned", AresValueHelper.CreateNumber(1));
+    planned.SetPlannedSource(new ParameterMetadata { Name = "Planned" });
+    planned.SetResolvedValue(AresValueHelper.CreateNumber(2));
+    var environment = CreateParameter("Environment", AresValueHelper.CreateString("initial"));
+    environment.SetEnvironmentSource(VariableType.VarUnspecified, "environment");
+    environment.SetResolvedValue(structValue);
+    var variable = CreateParameter("Variable", AresValueHelper.CreateString("initial"));
+    variable.SetCommandVariableSource("previous");
+    variable.SetResolvedValue(AresValueHelper.CreateList([AresValueHelper.CreateNumber(3), AresValueHelper.CreateNumber(4)]));
+    var template = CreateCommandTemplate("command-template", literal, planned, environment, variable);
+    var command = CreateCommand(
+      DateTime.UnixEpoch,
+      DateTime.UnixEpoch.AddSeconds(1),
+      result: new CommandResult { Result = AresValueHelper.CreateNumber(10) },
+      templateId: template.UniqueId);
+    var experiment = CreateExperiment(
+      DateTime.UnixEpoch,
+      DateTime.UnixEpoch.AddSeconds(2),
+      steps: [CreateStep("step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(2), command)]);
+    SetCommandTemplates(experiment, template);
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+    var columns = dataset.Columns.Select(column => column.Name).ToArray();
+    var row = dataset.Rows.Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(columns, Does.Contain("Input.Literal"));
+      Assert.That(columns, Does.Contain("Input.Planned"));
+      Assert.That(columns, Does.Contain("Input.Environment.Temperature"));
+      Assert.That(columns, Does.Contain("Input.Variable"));
+      Assert.That(Array.IndexOf(columns, "Input.Literal"), Is.LessThan(Array.IndexOf(columns, "Output")));
+      Assert.That(row.Data.Fields["Input.Literal"].StringValue, Is.EqualTo("literal"));
+      Assert.That(row.Data.Fields["Input.Planned"].NumberValue, Is.EqualTo(2));
+      Assert.That(row.Data.Fields["Input.Environment.Temperature"].NumberValue, Is.EqualTo(22.5));
+      Assert.That(row.Data.Fields["Input.Variable"].ListValue.Values.Select(value => value.NumberValue), Is.EqualTo([3, 4]));
+      Assert.That(row.Data.Fields["Output"].NumberValue, Is.EqualTo(10));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_MatchesCommandInputsByTemplateId()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var firstTemplate = CreateCommandTemplate("first-template", CreateParameter("Value", AresValueHelper.CreateString("first")));
+    var secondTemplate = CreateCommandTemplate("second-template", CreateParameter("Value", AresValueHelper.CreateString("second")));
+    var unmatchedCommand = CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), commandName: "Unmatched", templateId: Guid.NewGuid().ToString());
+    var matchedCommand = CreateCommand(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), commandName: "Matched", templateId: secondTemplate.UniqueId);
+    var experiment = CreateExperiment(
+      DateTime.UnixEpoch,
+      DateTime.UnixEpoch.AddSeconds(4),
+      steps: [CreateStep("step", DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(4), unmatchedCommand, matchedCommand)]);
+    SetCommandTemplates(experiment, firstTemplate, secondTemplate);
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Rows[0].Data.Fields.ContainsKey("Input.Value"), Is.False);
+      Assert.That(dataset.Rows[1].Data.Fields["Input.Value"].StringValue, Is.EqualTo("second"));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_UsesAnySchemaForConflictingCommandInputTypes()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var firstTemplate = CreateCommandTemplate("first-template", CreateParameter("Value", AresValueHelper.CreateNumber(1)));
+    var secondTemplate = CreateCommandTemplate("second-template", CreateParameter("Value", AresValueHelper.CreateString("one")));
+    var experiment = CreateExperiment(
+      DateTime.UnixEpoch,
+      DateTime.UnixEpoch.AddSeconds(4),
+      steps: [
+        CreateStep(
+          "step",
+          DateTime.UnixEpoch,
+          DateTime.UnixEpoch.AddSeconds(4),
+          CreateCommand(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), templateId: firstTemplate.UniqueId),
+          CreateCommand(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), templateId: secondTemplate.UniqueId))
+      ]);
+    SetCommandTemplates(experiment, firstTemplate, secondTemplate);
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment));
+
+    var dataset = GetDataset(await generator.GenerateAsync(summaryId), "Commands");
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(ColumnSchema(dataset, "Input.Value").Type, Is.EqualTo(AresDataType.Any));
+      Assert.That(ColumnSchema(dataset, "Input.Value").Optional, Is.True);
+    }
+  }
+
+  [Test]
   public async Task GenerateAsync_ExcludesStartupAndCloseoutCommands()
   {
     var summaryId = Guid.NewGuid().ToString();
@@ -678,11 +779,13 @@ internal class CampaignDatasetGeneratorTests
     string commandName = "",
     string commandDescription = "",
     CommandStatusCode statusCode = CommandStatusCode.StatusUnspecified,
-    CommandResult result = null)
+    CommandResult result = null,
+    string templateId = "")
   {
     var command = new CommandExecutionSummary
     {
       UniqueId = Guid.NewGuid().ToString(),
+      TemplateId = templateId,
       CommandName = commandName,
       CommandDescription = commandDescription,
       StatusCode = statusCode,
@@ -711,6 +814,46 @@ internal class CampaignDatasetGeneratorTests
     parameter.SetLiteralSource(value);
 
     return parameter;
+  }
+
+  private static CommandTemplate CreateCommandTemplate(string uniqueId, params Parameter[] parameters)
+  {
+    foreach(var parameter in parameters)
+    {
+      if(string.IsNullOrWhiteSpace(parameter.UniqueId))
+        parameter.UniqueId = Guid.NewGuid().ToString();
+
+      if(parameter.Metadata is not null && string.IsNullOrWhiteSpace(parameter.Metadata.UniqueId))
+        parameter.Metadata.UniqueId = Guid.NewGuid().ToString();
+    }
+
+    var template = new CommandTemplate
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      Metadata = new CommandMetadata
+      {
+        UniqueId = Guid.NewGuid().ToString(),
+        Name = uniqueId
+      }
+    };
+    template.Parameters.AddRange(parameters);
+    return template;
+  }
+
+  private static void SetCommandTemplates(ExperimentExecutionSummary experiment, params CommandTemplate[] commandTemplates)
+  {
+    var stepTemplate = new StepTemplate
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      Name = "Step"
+    };
+    stepTemplate.CommandTemplates.AddRange(commandTemplates);
+    experiment.ExperimentOverview.Template = new ExperimentTemplate
+    {
+      UniqueId = Guid.NewGuid().ToString(),
+      Name = "Experiment"
+    };
+    experiment.ExperimentOverview.Template.StepTemplates.Add(stepTemplate);
   }
 
   private static PlannerTransaction CreatePlannerTransaction(

--- a/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
+++ b/Ares.Core.Tests/DataManagement/DataMappers/CampaignDatasetGeneratorTests.cs
@@ -39,25 +39,33 @@ internal class CampaignDatasetGeneratorTests
 
     using(Assert.EnterMultipleScope())
     {
-      Assert.That(dataset.Name, Is.EqualTo("Campaign A"));
-      Assert.That(dataset.Columns.Take(4).Select(column => column.Name), Is.EqualTo([
+      Assert.That(dataset.Name, Is.EqualTo("Experiments"));
+      Assert.That(dataset.Columns.Take(9).Select(column => column.Name), Is.EqualTo([
         "Experiment Number",
+        "Experiment Execution ID",
+        "Experiment ID",
+        "Experiment Template",
         "Time Started",
         "Time Finished",
-        "Analysis Result"
+        "Duration Seconds",
+        "Analysis Result",
+        "Result Output Path"
       ]));
       Assert.That(ColumnSchema(dataset, "Experiment Number").Type, Is.EqualTo(AresDataType.Int));
       Assert.That(ColumnSchema(dataset, "Time Started").Type, Is.EqualTo(AresDataType.Timestamp));
       Assert.That(ColumnSchema(dataset, "Time Finished").Type, Is.EqualTo(AresDataType.Timestamp));
+      Assert.That(ColumnSchema(dataset, "Duration Seconds").Type, Is.EqualTo(AresDataType.Number));
       Assert.That(ColumnSchema(dataset, "Analysis Result").Type, Is.EqualTo(AresDataType.Number));
       Assert.That(ColumnSchema(dataset, "Analysis Result").Optional, Is.True);
       Assert.That(dataset.Rows[0].Data.Fields["Experiment Number"].IntValue, Is.EqualTo(1));
       Assert.That(dataset.Rows[0].Data.Fields["Time Started"].TimestampValue, Is.EqualTo(Timestamp.FromDateTime(firstStart)));
       Assert.That(dataset.Rows[0].Data.Fields["Time Finished"].TimestampValue, Is.EqualTo(Timestamp.FromDateTime(firstEnd)));
+      Assert.That(dataset.Rows[0].Data.Fields["Duration Seconds"].NumberValue, Is.EqualTo(1));
       Assert.That(dataset.Rows[0].Data.Fields["Analysis Result"].NumberValue, Is.EqualTo(1.5));
       Assert.That(dataset.Rows[1].Data.Fields["Experiment Number"].IntValue, Is.EqualTo(2));
       Assert.That(dataset.Rows[1].Data.Fields["Time Started"].TimestampValue, Is.EqualTo(Timestamp.FromDateTime(secondStart)));
       Assert.That(dataset.Rows[1].Data.Fields["Time Finished"].TimestampValue, Is.EqualTo(Timestamp.FromDateTime(secondEnd)));
+      Assert.That(dataset.Rows[1].Data.Fields["Duration Seconds"].NumberValue, Is.EqualTo(1));
       Assert.That(dataset.Rows[1].Data.Fields["Analysis Result"].NumberValue, Is.EqualTo(2.5));
     }
   }
@@ -84,17 +92,99 @@ internal class CampaignDatasetGeneratorTests
 
     using(Assert.EnterMultipleScope())
     {
-      Assert.That(ColumnSchema(dataset, "Yield").Type, Is.EqualTo(AresDataType.Number));
-      Assert.That(ColumnSchema(dataset, "Yield").Optional, Is.True);
-      Assert.That(ColumnSchema(dataset, "Comment").Type, Is.EqualTo(AresDataType.String));
-      Assert.That(ColumnSchema(dataset, "Comment").Optional, Is.True);
-      Assert.That(ColumnSchema(dataset, "Mass").Type, Is.EqualTo(AresDataType.Quantity));
-      Assert.That(ColumnSchema(dataset, "Mass").Optional, Is.True);
-      Assert.That(dataset.Rows[0].Data.Fields["Yield"].NumberValue, Is.EqualTo(12.3));
-      Assert.That(dataset.Rows[0].Data.Fields["Comment"].StringValue, Is.EqualTo("before"));
-      Assert.That(dataset.Rows[0].Data.Fields.ContainsKey("Mass"), Is.False);
-      Assert.That(dataset.Rows[1].Data.Fields["Mass"].QuantityValue.Scalar, Is.EqualTo(4.5));
+      Assert.That(ColumnSchema(dataset, "Output.Yield").Type, Is.EqualTo(AresDataType.Number));
+      Assert.That(ColumnSchema(dataset, "Output.Yield").Optional, Is.True);
+      Assert.That(ColumnSchema(dataset, "Output.Comment").Type, Is.EqualTo(AresDataType.String));
+      Assert.That(ColumnSchema(dataset, "Output.Comment").Optional, Is.True);
+      Assert.That(ColumnSchema(dataset, "Output.Mass").Type, Is.EqualTo(AresDataType.Quantity));
+      Assert.That(ColumnSchema(dataset, "Output.Mass").Optional, Is.True);
+      Assert.That(dataset.Rows[0].Data.Fields["Output.Yield"].NumberValue, Is.EqualTo(12.3));
+      Assert.That(dataset.Rows[0].Data.Fields["Output.Comment"].StringValue, Is.EqualTo("before"));
+      Assert.That(dataset.Rows[0].Data.Fields.ContainsKey("Output.Mass"), Is.False);
+      Assert.That(dataset.Rows[1].Data.Fields["Output.Mass"].QuantityValue.Scalar, Is.EqualTo(4.5));
     }
+  }
+
+  [Test]
+  public async Task GenerateAsync_IncludesExperimentIdentityTemplateAndOutputPath()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var experiment = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1));
+    experiment.ExperimentId = "experiment-id";
+    experiment.ExperimentOverview.Template = new ExperimentTemplate { Name = "Template A" };
+    experiment.ResultOutputPath = "results/experiment.json";
+    var generator = CreateGenerator(CreateCampaignSummary(summaryId, "Campaign A", experiment));
+
+    var row = (await generator.GenerateAsync(summaryId)).Single().Rows.Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(row.Data.Fields["Experiment Execution ID"].StringValue, Is.EqualTo(experiment.UniqueId));
+      Assert.That(row.Data.Fields["Experiment ID"].StringValue, Is.EqualTo("experiment-id"));
+      Assert.That(row.Data.Fields["Experiment Template"].StringValue, Is.EqualTo("Template A"));
+      Assert.That(row.Data.Fields["Result Output Path"].StringValue, Is.EqualTo("results/experiment.json"));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_RecursivelyFlattensStructParametersAndResults()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var result = AresValueHelper.CreateStruct();
+    result.StructValue.Fields["Nested"] = AresValueHelper.CreateStruct();
+    result.StructValue.Fields["Nested"].StructValue.Fields["Value"] = AresValueHelper.CreateNumber(12.3);
+    var parameter = AresValueHelper.CreateStruct();
+    parameter.StructValue.Fields["Temp1"] = AresValueHelper.CreateNumber(22.5);
+    var generator = CreateGenerator(CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(
+        DateTime.UnixEpoch,
+        DateTime.UnixEpoch.AddSeconds(1),
+        resultFields: [("Metrics", result)],
+        parameters: [CreateParameter("Temperatures", parameter)])));
+
+    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+
+    using(Assert.EnterMultipleScope())
+    {
+      Assert.That(dataset.Columns.Select(column => column.Name), Does.Contain("Output.Metrics.Nested.Value"));
+      Assert.That(dataset.Columns.Select(column => column.Name), Does.Contain("Input.Temperatures.Temp1"));
+      Assert.That(dataset.Rows.Single().Data.Fields["Output.Metrics.Nested.Value"].NumberValue, Is.EqualTo(12.3));
+      Assert.That(dataset.Rows.Single().Data.Fields["Input.Temperatures.Temp1"].NumberValue, Is.EqualTo(22.5));
+    }
+  }
+
+  [Test]
+  public async Task GenerateAsync_UsesAnySchemaForConflictingDynamicTypes()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var generator = CreateGenerator(CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1), resultFields: [("Value", AresValueHelper.CreateNumber(1))]),
+      CreateExperiment(DateTime.UnixEpoch.AddSeconds(2), DateTime.UnixEpoch.AddSeconds(3), resultFields: [("Value", AresValueHelper.CreateString("one"))])));
+
+    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+
+    Assert.That(ColumnSchema(dataset, "Output.Value").Type, Is.EqualTo(AresDataType.Any));
+  }
+
+  [Test]
+  public async Task GenerateAsync_ExcludesStartupAndCloseoutSummaries()
+  {
+    var summaryId = Guid.NewGuid().ToString();
+    var summary = CreateCampaignSummary(
+      summaryId,
+      "Campaign A",
+      CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1)));
+    summary.StartupExecutionSummary = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1));
+    summary.CloseoutExecutionSummary = CreateExperiment(DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1));
+    var generator = CreateGenerator(summary);
+
+    var dataset = (await generator.GenerateAsync(summaryId)).Single();
+
+    Assert.That(dataset.Rows, Has.Count.EqualTo(1));
   }
 
   [Test]
@@ -119,11 +209,11 @@ internal class CampaignDatasetGeneratorTests
 
     using(Assert.EnterMultipleScope())
     {
-      Assert.That(ColumnSchema(dataset, "Parameter.Temperature").Type, Is.EqualTo(AresDataType.Quantity));
-      Assert.That(ColumnSchema(dataset, "Parameter.Temperature").Optional, Is.True);
-      Assert.That(ColumnSchema(dataset, $"Parameter.{parameterId}").Type, Is.EqualTo(AresDataType.String));
-      Assert.That(dataset.Rows.Single().Data.Fields["Parameter.Temperature"].QuantityValue.Scalar, Is.EqualTo(22.5));
-      Assert.That(dataset.Rows.Single().Data.Fields[$"Parameter.{parameterId}"].StringValue, Is.EqualTo("fallback"));
+      Assert.That(ColumnSchema(dataset, "Input.Temperature").Type, Is.EqualTo(AresDataType.Quantity));
+      Assert.That(ColumnSchema(dataset, "Input.Temperature").Optional, Is.True);
+      Assert.That(ColumnSchema(dataset, $"Input.{parameterId}").Type, Is.EqualTo(AresDataType.String));
+      Assert.That(dataset.Rows.Single().Data.Fields["Input.Temperature"].QuantityValue.Scalar, Is.EqualTo(22.5));
+      Assert.That(dataset.Rows.Single().Data.Fields[$"Input.{parameterId}"].StringValue, Is.EqualTo("fallback"));
     }
   }
 

--- a/Ares.Core/Analyzing/AnalysisHelper.cs
+++ b/Ares.Core/Analyzing/AnalysisHelper.cs
@@ -54,6 +54,7 @@ public class AnalysisHelper
       transaction.AnalyzerId = analyzer.UniqueId;
       transaction.AnalyzerName = analyzer.Name;
       transaction.AnalyzerType = analyzer.Type;
+      transaction.AnalyzerVersion = analyzer.Version;
       transaction.AnalysisRequest = analysisRequest;
       transaction.TimeRequestSent = DateTime.UtcNow.ToTimestamp();
 

--- a/Ares.Core/DataManagement/DataMappers/AresValueFlattener.cs
+++ b/Ares.Core/DataManagement/DataMappers/AresValueFlattener.cs
@@ -1,0 +1,23 @@
+using Ares.Datamodel;
+
+namespace Ares.Core.DataManagement.DataMappers;
+
+public static class AresValueFlattener
+{
+  public static IEnumerable<KeyValuePair<string, AresValue>> Flatten(string fieldName, AresValue value)
+  {
+    if(value.KindCase != AresValue.KindOneofCase.StructValue)
+    {
+      yield return KeyValuePair.Create(fieldName, value);
+      yield break;
+    }
+
+    foreach(var childField in value.StructValue.Fields)
+    {
+      foreach(var flattenedChildField in Flatten($"{fieldName}.{childField.Key}", childField.Value))
+      {
+        yield return flattenedChildField;
+      }
+    }
+  }
+}

--- a/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
+++ b/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
@@ -169,7 +169,8 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
       CreateColumn(StatusColumnName, AresDataType.String, optional: true),
       CreateColumn(SuccessColumnName, AresDataType.Boolean, optional: true),
       CreateColumn(ErrorColumnName, AresDataType.String, optional: true),
-      .. CreateCommandDynamicColumns(commandRecords, cancellationToken)
+      .. CreateCommandInputColumns(commandRecords, cancellationToken),
+      .. CreateCommandOutputColumns(commandRecords, cancellationToken)
     ];
   }
 
@@ -257,7 +258,25 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     });
   }
 
-  private static IEnumerable<AresDataColumn> CreateCommandDynamicColumns(IEnumerable<CommandRecord> commandRecords, CancellationToken cancellationToken)
+  private static IEnumerable<AresDataColumn> CreateCommandInputColumns(IEnumerable<CommandRecord> commandRecords, CancellationToken cancellationToken)
+  {
+    var columns = new Dictionary<string, AresValueSchema>();
+
+    foreach(var commandRecord in commandRecords)
+    {
+      foreach(var parameter in commandRecord.Template?.Parameters ?? [])
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        var value = parameter.GetValue();
+        if(value is not null)
+          AddDynamicColumns(columns, GetParameterColumnName(parameter), value);
+      }
+    }
+
+    return CreateDynamicColumns(columns);
+  }
+
+  private static IEnumerable<AresDataColumn> CreateCommandOutputColumns(IEnumerable<CommandRecord> commandRecords, CancellationToken cancellationToken)
   {
     var columns = new Dictionary<string, AresValueSchema>();
 
@@ -338,6 +357,7 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     foreach(var experimentItem in experiments.Select((experiment, index) => new { Experiment = experiment, ExperimentNumber = index + 1 }))
     {
       cancellationToken.ThrowIfCancellationRequested();
+      var commandTemplates = CreateUniqueCommandTemplateMap(experimentItem.Experiment);
 
       var steps = experimentItem.Experiment.StepSummaries
         .OrderBy(step => step.ExecutionInfo?.TimeStarted)
@@ -354,16 +374,28 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
         foreach(var commandItem in commands.Select((command, index) => new { Command = command, CommandNumber = index + 1 }))
         {
           cancellationToken.ThrowIfCancellationRequested();
+          commandTemplates.TryGetValue(commandItem.Command.TemplateId, out var commandTemplate);
           yield return new CommandRecord(
             experimentItem.Experiment,
             experimentItem.ExperimentNumber,
             stepItem.Step,
             stepItem.StepNumber,
             commandItem.Command,
-            commandItem.CommandNumber);
+            commandItem.CommandNumber,
+            commandTemplate);
         }
       }
     }
+  }
+
+  private static IReadOnlyDictionary<string, CommandTemplate> CreateUniqueCommandTemplateMap(ExperimentExecutionSummary experiment)
+  {
+    return (experiment.ExperimentOverview?.Template?.StepTemplates ?? [])
+      .SelectMany(step => step.CommandTemplates)
+      .Where(template => !string.IsNullOrWhiteSpace(template.UniqueId))
+      .GroupBy(template => template.UniqueId)
+      .Where(group => group.Count() == 1)
+      .ToDictionary(group => group.Key, group => group.Single());
   }
 
   private static void TryAddDynamicColumn(IDictionary<string, AresValueSchema> columns, string columnName, AresValue? value)
@@ -428,6 +460,14 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     AddString(data, CommandDescriptionColumnName, record.Command.CommandDescription);
     AddExecutionFields(data, record.Command.ExecutionInfo);
     AddString(data, StatusColumnName, record.Command.StatusCode.ToString());
+
+    foreach(var parameter in record.Template?.Parameters ?? [])
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      var value = parameter.GetValue();
+      if(value is not null)
+        AddFlattenedValue(data, GetParameterColumnName(parameter), value, cancellationToken);
+    }
 
     if(record.Command.Result is not null)
     {
@@ -638,7 +678,8 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     StepExecutionSummary Step,
     int StepNumber,
     CommandExecutionSummary Command,
-    int CommandNumber);
+    int CommandNumber,
+    CommandTemplate? Template);
 
   private record PlannerRecord(PlannerTransaction Transaction, int ExperimentNumber);
 

--- a/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
+++ b/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
@@ -8,16 +8,21 @@ namespace Ares.Core.DataManagement.DataMappers;
 public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _dbContextFactory)
 {
   private const string ExperimentNumberColumnName = "Experiment Number";
-  private const string ExperimentExecutionIdColumnName = "Experiment Execution ID";
-  private const string ExperimentIdColumnName = "Experiment ID";
   private const string ExperimentTemplateColumnName = "Experiment Template";
+  private const string StepNumberColumnName = "Step Number";
+  private const string CommandNumberColumnName = "Command Number";
+  private const string CommandNameColumnName = "Command Name";
+  private const string CommandDescriptionColumnName = "Command Description";
   private const string TimeStartedColumnName = "Time Started";
   private const string TimeFinishedColumnName = "Time Finished";
   private const string DurationSecondsColumnName = "Duration Seconds";
   private const string AnalysisResultColumnName = "Analysis Result";
-  private const string ResultOutputPathColumnName = "Result Output Path";
+  private const string StatusColumnName = "Status";
+  private const string SuccessColumnName = "Success";
+  private const string ErrorColumnName = "Error";
   private const string InputColumnPrefix = "Input.";
   private const string OutputColumnPrefix = "Output.";
+  private const string OutputColumnName = "Output";
 
   public async ValueTask<AresDataset[]> GenerateAsync(string summaryId, CancellationToken cancellationToken = default)
   {
@@ -32,44 +37,71 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
       .OrderBy(experiment => experiment.ExecutionInfo?.TimeStarted)
       .ToArray();
 
+    return [
+      CreateExperimentsDataset(experiments, cancellationToken),
+      CreateCommandsDataset(experiments, cancellationToken)
+    ];
+  }
+
+  private static AresDataset CreateExperimentsDataset(ExperimentExecutionSummary[] experiments, CancellationToken cancellationToken)
+  {
     var dataset = new AresDataset
     {
       Name = "Experiments"
     };
 
-    dataset.Columns.AddRange(CreateFixedColumns());
-    dataset.Columns.AddRange(CreateDynamicColumns(experiments, cancellationToken));
-    dataset.Rows.AddRange(experiments.Select((experiment, index) => CreateRow(experiment, index + 1, cancellationToken)));
-
-    return [dataset];
+    dataset.Columns.AddRange(CreateExperimentColumns(experiments, cancellationToken));
+    dataset.Rows.AddRange(experiments.Select((experiment, index) => CreateExperimentRow(experiment, index + 1, cancellationToken)));
+    return dataset;
   }
 
-  private static IEnumerable<AresDataColumn> CreateFixedColumns()
+  private static AresDataset CreateCommandsDataset(ExperimentExecutionSummary[] experiments, CancellationToken cancellationToken)
+  {
+    var commandRecords = CreateCommandRecords(experiments, cancellationToken).ToArray();
+    var dataset = new AresDataset
+    {
+      Name = "Commands"
+    };
+
+    dataset.Columns.AddRange(CreateCommandColumns(commandRecords, cancellationToken));
+    dataset.Rows.AddRange(commandRecords.Select(record => CreateCommandRow(record, cancellationToken)));
+    return dataset;
+  }
+
+  private static IEnumerable<AresDataColumn> CreateExperimentColumns(IEnumerable<ExperimentExecutionSummary> experiments, CancellationToken cancellationToken)
   {
     return
     [
       CreateColumn(ExperimentNumberColumnName, AresDataType.Int),
-      CreateColumn(ExperimentExecutionIdColumnName, AresDataType.String, optional: true),
-      CreateColumn(ExperimentIdColumnName, AresDataType.String, optional: true),
       CreateColumn(ExperimentTemplateColumnName, AresDataType.String, optional: true),
       CreateColumn(TimeStartedColumnName, AresDataType.Timestamp, optional: true),
       CreateColumn(TimeFinishedColumnName, AresDataType.Timestamp, optional: true),
       CreateColumn(DurationSecondsColumnName, AresDataType.Number, optional: true),
       CreateColumn(AnalysisResultColumnName, AresDataType.Number, optional: true),
-      CreateColumn(ResultOutputPathColumnName, AresDataType.String, optional: true)
+      .. CreateExperimentDynamicColumns(experiments, cancellationToken)
     ];
   }
 
-  private static AresDataColumn CreateColumn(string name, AresDataType type, bool optional = false)
+  private static IEnumerable<AresDataColumn> CreateCommandColumns(IEnumerable<CommandRecord> commandRecords, CancellationToken cancellationToken)
   {
-    return new AresDataColumn
-    {
-      Name = name,
-      Schema = new AresValueSchema { Type = type, Optional = optional }
-    };
+    return
+    [
+      CreateColumn(ExperimentNumberColumnName, AresDataType.Int),
+      CreateColumn(StepNumberColumnName, AresDataType.Int),
+      CreateColumn(CommandNumberColumnName, AresDataType.Int),
+      CreateColumn(CommandNameColumnName, AresDataType.String, optional: true),
+      CreateColumn(CommandDescriptionColumnName, AresDataType.String, optional: true),
+      CreateColumn(TimeStartedColumnName, AresDataType.Timestamp, optional: true),
+      CreateColumn(TimeFinishedColumnName, AresDataType.Timestamp, optional: true),
+      CreateColumn(DurationSecondsColumnName, AresDataType.Number, optional: true),
+      CreateColumn(StatusColumnName, AresDataType.String, optional: true),
+      CreateColumn(SuccessColumnName, AresDataType.Boolean, optional: true),
+      CreateColumn(ErrorColumnName, AresDataType.String, optional: true),
+      .. CreateCommandDynamicColumns(commandRecords, cancellationToken)
+    ];
   }
 
-  private static IEnumerable<AresDataColumn> CreateDynamicColumns(IEnumerable<ExperimentExecutionSummary> experiments, CancellationToken cancellationToken)
+  private static IEnumerable<AresDataColumn> CreateExperimentDynamicColumns(IEnumerable<ExperimentExecutionSummary> experiments, CancellationToken cancellationToken)
   {
     var columns = new Dictionary<string, AresValueSchema>();
 
@@ -111,6 +143,64 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     });
   }
 
+  private static IEnumerable<AresDataColumn> CreateCommandDynamicColumns(IEnumerable<CommandRecord> commandRecords, CancellationToken cancellationToken)
+  {
+    var columns = new Dictionary<string, AresValueSchema>();
+
+    foreach(var commandRecord in commandRecords)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      var output = commandRecord.Command.Result?.Result;
+      if(output is null || output.KindCase == AresValue.KindOneofCase.None)
+        continue;
+
+      foreach(var flattenedField in AresValueFlattener.Flatten(OutputColumnName, output))
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        TryAddDynamicColumn(columns, flattenedField.Key, flattenedField.Value);
+      }
+    }
+
+    return columns.Select(column => new AresDataColumn
+    {
+      Name = column.Key,
+      Schema = column.Value
+    });
+  }
+
+  private static IEnumerable<CommandRecord> CreateCommandRecords(IEnumerable<ExperimentExecutionSummary> experiments, CancellationToken cancellationToken)
+  {
+    foreach(var experimentItem in experiments.Select((experiment, index) => new { Experiment = experiment, ExperimentNumber = index + 1 }))
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      var steps = experimentItem.Experiment.StepSummaries
+        .OrderBy(step => step.ExecutionInfo?.TimeStarted)
+        .ToArray();
+
+      foreach(var stepItem in steps.Select((step, index) => new { Step = step, StepNumber = index + 1 }))
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var commands = stepItem.Step.CommandSummaries
+          .OrderBy(command => command.ExecutionInfo?.TimeStarted)
+          .ToArray();
+
+        foreach(var commandItem in commands.Select((command, index) => new { Command = command, CommandNumber = index + 1 }))
+        {
+          cancellationToken.ThrowIfCancellationRequested();
+          yield return new CommandRecord(
+            experimentItem.Experiment,
+            experimentItem.ExperimentNumber,
+            stepItem.Step,
+            stepItem.StepNumber,
+            commandItem.Command,
+            commandItem.CommandNumber);
+        }
+      }
+    }
+  }
+
   private static void TryAddDynamicColumn(IDictionary<string, AresValueSchema> columns, string columnName, AresValue? value)
   {
     if(value is null)
@@ -128,33 +218,17 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
       existingSchema.Type = AresDataType.Any;
   }
 
-  private static AresDataRow CreateRow(ExperimentExecutionSummary experiment, int experimentNumber, CancellationToken cancellationToken)
+  private static AresDataRow CreateExperimentRow(ExperimentExecutionSummary experiment, int experimentNumber, CancellationToken cancellationToken)
   {
     cancellationToken.ThrowIfCancellationRequested();
 
     var data = new AresStruct();
-    data.Fields[ExperimentNumberColumnName] = AresValueHelper.CreateInt(experimentNumber);
-
-    AddString(data, ExperimentExecutionIdColumnName, experiment.HasUniqueId ? experiment.UniqueId : null);
-    AddString(data, ExperimentIdColumnName, experiment.ExperimentId);
+    AddExperimentFields(data, experiment, experimentNumber);
     AddString(data, ExperimentTemplateColumnName, experiment.ExperimentOverview?.Template?.Name);
-
-    if(experiment.ExecutionInfo?.TimeStarted is not null)
-      data.Fields[TimeStartedColumnName] = AresValueHelper.CreateTimestamp(experiment.ExecutionInfo.TimeStarted);
-
-    if(experiment.ExecutionInfo?.TimeFinished is not null)
-      data.Fields[TimeFinishedColumnName] = AresValueHelper.CreateTimestamp(experiment.ExecutionInfo.TimeFinished);
-
-    if(experiment.ExecutionInfo?.TimeStarted is not null && experiment.ExecutionInfo.TimeFinished is not null)
-    {
-      var duration = experiment.ExecutionInfo.TimeFinished.ToDateTime() - experiment.ExecutionInfo.TimeStarted.ToDateTime();
-      data.Fields[DurationSecondsColumnName] = AresValueHelper.CreateNumber(duration.TotalSeconds);
-    }
+    AddExecutionFields(data, experiment.ExecutionInfo);
 
     if(experiment.ExperimentOverview?.AnalysisOverview is not null)
       data.Fields[AnalysisResultColumnName] = AresValueHelper.CreateNumber(experiment.ExperimentOverview.AnalysisOverview.Result);
-
-    AddString(data, ResultOutputPathColumnName, experiment.ResultOutputPath);
 
     foreach(var field in experiment.ExperimentOverview?.Result?.Fields ?? [])
     {
@@ -175,6 +249,63 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     {
       Data = data
     };
+  }
+
+  private static AresDataRow CreateCommandRow(CommandRecord record, CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+
+    var data = new AresStruct();
+    AddExperimentFields(data, record.Experiment, record.ExperimentNumber);
+    data.Fields[StepNumberColumnName] = AresValueHelper.CreateInt(record.StepNumber);
+    data.Fields[CommandNumberColumnName] = AresValueHelper.CreateInt(record.CommandNumber);
+    AddString(data, CommandNameColumnName, record.Command.CommandName);
+    AddString(data, CommandDescriptionColumnName, record.Command.CommandDescription);
+    AddExecutionFields(data, record.Command.ExecutionInfo);
+    AddString(data, StatusColumnName, record.Command.StatusCode.ToString());
+
+    if(record.Command.Result is not null)
+    {
+      data.Fields[SuccessColumnName] = AresValueHelper.CreateBool(record.Command.Result.Success);
+      AddString(data, ErrorColumnName, record.Command.Result.Error);
+
+      if(record.Command.Result.Result is not null && record.Command.Result.Result.KindCase != AresValue.KindOneofCase.None)
+        AddFlattenedValue(data, OutputColumnName, record.Command.Result.Result, cancellationToken);
+    }
+
+    return new AresDataRow
+    {
+      Data = data
+    };
+  }
+
+  private static AresDataColumn CreateColumn(string name, AresDataType type, bool optional = false)
+  {
+    return new AresDataColumn
+    {
+      Name = name,
+      Schema = new AresValueSchema { Type = type, Optional = optional }
+    };
+  }
+
+  private static void AddExperimentFields(AresStruct data, ExperimentExecutionSummary experiment, int experimentNumber)
+  {
+    data.Fields[ExperimentNumberColumnName] = AresValueHelper.CreateInt(experimentNumber);
+  }
+
+  private static void AddExecutionFields(AresStruct data, ExecutionInfo? executionInfo)
+  {
+    if(executionInfo?.TimeStarted is not null)
+      data.Fields[TimeStartedColumnName] = AresValueHelper.CreateTimestamp(executionInfo.TimeStarted);
+
+    if(executionInfo?.TimeFinished is not null)
+      data.Fields[TimeFinishedColumnName] = AresValueHelper.CreateTimestamp(executionInfo.TimeFinished);
+
+    if(executionInfo?.TimeStarted is not null && executionInfo.TimeFinished is not null)
+    {
+      var duration = executionInfo.TimeFinished.ToDateTime() - executionInfo.TimeStarted.ToDateTime();
+      data.Fields[DurationSecondsColumnName] = AresValueHelper.CreateNumber(duration.TotalSeconds);
+    }
   }
 
   private static void AddString(AresStruct data, string columnName, string? value)
@@ -202,4 +333,12 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
 
     return $"{InputColumnPrefix}{parameter.Index}";
   }
+
+  private record CommandRecord(
+    ExperimentExecutionSummary Experiment,
+    int ExperimentNumber,
+    StepExecutionSummary Step,
+    int StepNumber,
+    CommandExecutionSummary Command,
+    int CommandNumber);
 }

--- a/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
+++ b/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
@@ -1,6 +1,10 @@
 using Ares.Datamodel;
+using Ares.Datamodel.Analyzing;
+using Ares.Datamodel.Analyzing.Remote;
 using Ares.Datamodel.Extensions;
+using Ares.Datamodel.Planning;
 using Ares.Datamodel.Templates;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.EntityFrameworkCore;
 
 namespace Ares.Core.DataManagement.DataMappers;
@@ -20,6 +24,17 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
   private const string StatusColumnName = "Status";
   private const string SuccessColumnName = "Success";
   private const string ErrorColumnName = "Error";
+  private const string PlannerNameColumnName = "Planner Name";
+  private const string PlannerTypeColumnName = "Planner Type";
+  private const string PlannerVersionColumnName = "Planner Version";
+  private const string AnalyzerNameColumnName = "Analyzer Name";
+  private const string AnalyzerTypeColumnName = "Analyzer Type";
+  private const string AnalyzerVersionColumnName = "Analyzer Version";
+  private const string TimeRequestSentColumnName = "Time Request Sent";
+  private const string TimeResponseReceivedColumnName = "Time Response Received";
+  private const string OutcomeColumnName = "Outcome";
+  private const string AnalysisResultsColumnName = "Analysis Results";
+  private const string ResultColumnName = "Result";
   private const string InputColumnPrefix = "Input.";
   private const string OutputColumnPrefix = "Output.";
   private const string OutputColumnName = "Output";
@@ -36,10 +51,43 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     var experiments = summary.ExperimentSummaries
       .OrderBy(experiment => experiment.ExecutionInfo?.TimeStarted)
       .ToArray();
+    var experimentNumbers = experiments
+      .Select((experiment, index) => new { experiment.ExperimentId, ExperimentNumber = index + 1 })
+      .Where(item => !string.IsNullOrWhiteSpace(item.ExperimentId))
+      .GroupBy(item => item.ExperimentId)
+      .ToDictionary(group => group.Key, group => group.First().ExperimentNumber);
+    var plannerRecords = new List<PlannerRecord>();
+    var analyzerRecords = new List<AnalyzerRecord>();
+    var campaignStart = summary.ExecutionInfo?.TimeStarted;
+    var campaignEnd = summary.ExecutionInfo?.TimeFinished;
+    if(campaignStart is not null && campaignEnd is not null)
+    {
+      var plannerTransactions = await ctx.PlannerTransactions
+        .Where(transaction => transaction.TimeRequestSent >= campaignStart && transaction.TimeResponseReceived <= campaignEnd)
+        .ToListAsync(cancellationToken);
+      foreach(var transaction in plannerTransactions)
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        if(TryCreatePlannerRecord(transaction, summary, experimentNumbers, out var record))
+          plannerRecords.Add(record);
+      }
+
+      var analyzerTransactions = await ctx.AnalyzerTransactions
+        .Where(transaction => transaction.TimeRequestSent >= campaignStart && transaction.TimeResponseReceived <= campaignEnd)
+        .ToListAsync(cancellationToken);
+      foreach(var transaction in analyzerTransactions)
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        if(TryCreateAnalyzerRecord(transaction, summary, experimentNumbers, out var record))
+          analyzerRecords.Add(record);
+      }
+    }
 
     return [
       CreateExperimentsDataset(experiments, cancellationToken),
-      CreateCommandsDataset(experiments, cancellationToken)
+      CreateCommandsDataset(experiments, cancellationToken),
+      CreatePlannerTransactionsDataset(plannerRecords.OrderBy(record => record.Transaction.TimeRequestSent).ToArray(), cancellationToken),
+      CreateAnalyzerTransactionsDataset(analyzerRecords.OrderBy(record => record.Transaction.TimeRequestSent).ToArray(), cancellationToken)
     ];
   }
 
@@ -65,6 +113,30 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
 
     dataset.Columns.AddRange(CreateCommandColumns(commandRecords, cancellationToken));
     dataset.Rows.AddRange(commandRecords.Select(record => CreateCommandRow(record, cancellationToken)));
+    return dataset;
+  }
+
+  private static AresDataset CreatePlannerTransactionsDataset(PlannerRecord[] records, CancellationToken cancellationToken)
+  {
+    var dataset = new AresDataset
+    {
+      Name = "Planner Transactions"
+    };
+
+    dataset.Columns.AddRange(CreatePlannerTransactionColumns(records, cancellationToken));
+    dataset.Rows.AddRange(records.Select(record => CreatePlannerTransactionRow(record, cancellationToken)));
+    return dataset;
+  }
+
+  private static AresDataset CreateAnalyzerTransactionsDataset(AnalyzerRecord[] records, CancellationToken cancellationToken)
+  {
+    var dataset = new AresDataset
+    {
+      Name = "Analyzer Transactions"
+    };
+
+    dataset.Columns.AddRange(CreateAnalyzerTransactionColumns(records, cancellationToken));
+    dataset.Rows.AddRange(records.Select(record => CreateAnalyzerTransactionRow(record, cancellationToken)));
     return dataset;
   }
 
@@ -98,6 +170,48 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
       CreateColumn(SuccessColumnName, AresDataType.Boolean, optional: true),
       CreateColumn(ErrorColumnName, AresDataType.String, optional: true),
       .. CreateCommandDynamicColumns(commandRecords, cancellationToken)
+    ];
+  }
+
+  private static IEnumerable<AresDataColumn> CreatePlannerTransactionColumns(IEnumerable<PlannerRecord> records, CancellationToken cancellationToken)
+  {
+    return
+    [
+      CreateColumn(ExperimentNumberColumnName, AresDataType.Int),
+      CreateColumn(PlannerNameColumnName, AresDataType.String, optional: true),
+      CreateColumn(PlannerTypeColumnName, AresDataType.String, optional: true),
+      CreateColumn(PlannerVersionColumnName, AresDataType.String, optional: true),
+      .. CreateTransactionTimingColumns(),
+      CreateColumn(OutcomeColumnName, AresDataType.String, optional: true),
+      CreateColumn(ErrorColumnName, AresDataType.String, optional: true),
+      CreateColumn(AnalysisResultsColumnName, AresDataType.List, optional: true),
+      .. CreatePlannerDynamicColumns(records, cancellationToken)
+    ];
+  }
+
+  private static IEnumerable<AresDataColumn> CreateAnalyzerTransactionColumns(IEnumerable<AnalyzerRecord> records, CancellationToken cancellationToken)
+  {
+    return
+    [
+      CreateColumn(ExperimentNumberColumnName, AresDataType.Int),
+      CreateColumn(AnalyzerNameColumnName, AresDataType.String, optional: true),
+      CreateColumn(AnalyzerTypeColumnName, AresDataType.String, optional: true),
+      CreateColumn(AnalyzerVersionColumnName, AresDataType.String, optional: true),
+      .. CreateTransactionTimingColumns(),
+      CreateColumn(ResultColumnName, AresDataType.Number, optional: true),
+      CreateColumn(OutcomeColumnName, AresDataType.String, optional: true),
+      CreateColumn(ErrorColumnName, AresDataType.String, optional: true),
+      .. CreateAnalyzerDynamicColumns(records, cancellationToken)
+    ];
+  }
+
+  private static IEnumerable<AresDataColumn> CreateTransactionTimingColumns()
+  {
+    return
+    [
+      CreateColumn(TimeRequestSentColumnName, AresDataType.Timestamp, optional: true),
+      CreateColumn(TimeResponseReceivedColumnName, AresDataType.Timestamp, optional: true),
+      CreateColumn(DurationSecondsColumnName, AresDataType.Number, optional: true)
     ];
   }
 
@@ -161,6 +275,57 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
       }
     }
 
+    return columns.Select(column => new AresDataColumn
+    {
+      Name = column.Key,
+      Schema = column.Value
+    });
+  }
+
+  private static IEnumerable<AresDataColumn> CreatePlannerDynamicColumns(IEnumerable<PlannerRecord> records, CancellationToken cancellationToken)
+  {
+    var columns = new Dictionary<string, AresValueSchema>();
+
+    foreach(var record in records)
+    {
+      foreach(var parameter in record.Transaction.PlanningResponse?.PlannedParameters ?? [])
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        if(parameter.ParameterValue is not null)
+          AddDynamicColumns(columns, $"{OutputColumnPrefix}{parameter.ParameterName}", parameter.ParameterValue);
+      }
+    }
+
+    return CreateDynamicColumns(columns);
+  }
+
+  private static IEnumerable<AresDataColumn> CreateAnalyzerDynamicColumns(IEnumerable<AnalyzerRecord> records, CancellationToken cancellationToken)
+  {
+    var columns = new Dictionary<string, AresValueSchema>();
+
+    foreach(var record in records)
+    {
+      foreach(var input in record.Transaction.AnalysisRequest?.Inputs?.Fields ?? [])
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        if(input.Value is not null)
+          AddDynamicColumns(columns, $"{InputColumnPrefix}{input.Key}", input.Value);
+      }
+    }
+
+    return CreateDynamicColumns(columns);
+  }
+
+  private static void AddDynamicColumns(IDictionary<string, AresValueSchema> columns, string columnName, AresValue value)
+  {
+    foreach(var flattenedField in AresValueFlattener.Flatten(columnName, value))
+    {
+      TryAddDynamicColumn(columns, flattenedField.Key, flattenedField.Value);
+    }
+  }
+
+  private static IEnumerable<AresDataColumn> CreateDynamicColumns(IDictionary<string, AresValueSchema> columns)
+  {
     return columns.Select(column => new AresDataColumn
     {
       Name = column.Key,
@@ -279,6 +444,66 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     };
   }
 
+  private static AresDataRow CreatePlannerTransactionRow(PlannerRecord record, CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+
+    var transaction = record.Transaction;
+    var data = new AresStruct();
+    data.Fields[ExperimentNumberColumnName] = AresValueHelper.CreateInt(record.ExperimentNumber);
+    AddString(data, PlannerNameColumnName, transaction.PlannerName);
+    AddString(data, PlannerTypeColumnName, transaction.PlannerType);
+    AddString(data, PlannerVersionColumnName, transaction.PlannerVersion);
+    AddTransactionTimingFields(data, transaction.TimeRequestSent, transaction.TimeResponseReceived);
+
+    if(transaction.PlanningResponse is not null)
+    {
+      AddString(data, OutcomeColumnName, transaction.PlanningResponse.PlanningOutcome.ToString());
+      AddString(data, ErrorColumnName, transaction.PlanningResponse.ErrorString);
+
+      foreach(var parameter in transaction.PlanningResponse.PlannedParameters)
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        if(parameter.ParameterValue is not null)
+          AddFlattenedValue(data, $"{OutputColumnPrefix}{parameter.ParameterName}", parameter.ParameterValue, cancellationToken);
+      }
+    }
+
+    if(transaction.PlanningRequest?.AnalysisResults.Count > 0)
+      data.Fields[AnalysisResultsColumnName] = AresValueHelper.CreateList(transaction.PlanningRequest.AnalysisResults.Select(AresValueHelper.CreateNumber));
+
+    return new AresDataRow { Data = data };
+  }
+
+  private static AresDataRow CreateAnalyzerTransactionRow(AnalyzerRecord record, CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+
+    var transaction = record.Transaction;
+    var data = new AresStruct();
+    data.Fields[ExperimentNumberColumnName] = AresValueHelper.CreateInt(record.ExperimentNumber);
+    AddString(data, AnalyzerNameColumnName, transaction.AnalyzerName);
+    AddString(data, AnalyzerTypeColumnName, transaction.AnalyzerType);
+    AddString(data, AnalyzerVersionColumnName, transaction.AnalyzerVersion);
+    AddTransactionTimingFields(data, transaction.TimeRequestSent, transaction.TimeResponseReceived);
+
+    if(transaction.AnalysisResponse is not null)
+    {
+      data.Fields[ResultColumnName] = AresValueHelper.CreateNumber(transaction.AnalysisResponse.Result);
+      AddString(data, OutcomeColumnName, transaction.AnalysisResponse.AnalysisOutcome.ToString());
+      AddString(data, ErrorColumnName, transaction.AnalysisResponse.ErrorString);
+    }
+
+    foreach(var input in transaction.AnalysisRequest?.Inputs?.Fields ?? [])
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      if(input.Value is not null)
+        AddFlattenedValue(data, $"{InputColumnPrefix}{input.Key}", input.Value, cancellationToken);
+    }
+
+    return new AresDataRow { Data = data };
+  }
+
   private static AresDataColumn CreateColumn(string name, AresDataType type, bool optional = false)
   {
     return new AresDataColumn
@@ -304,6 +529,21 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     if(executionInfo?.TimeStarted is not null && executionInfo.TimeFinished is not null)
     {
       var duration = executionInfo.TimeFinished.ToDateTime() - executionInfo.TimeStarted.ToDateTime();
+      data.Fields[DurationSecondsColumnName] = AresValueHelper.CreateNumber(duration.TotalSeconds);
+    }
+  }
+
+  private static void AddTransactionTimingFields(AresStruct data, Timestamp? requestSent, Timestamp? responseReceived)
+  {
+    if(requestSent is not null)
+      data.Fields[TimeRequestSentColumnName] = AresValueHelper.CreateTimestamp(requestSent);
+
+    if(responseReceived is not null)
+      data.Fields[TimeResponseReceivedColumnName] = AresValueHelper.CreateTimestamp(responseReceived);
+
+    if(requestSent is not null && responseReceived is not null)
+    {
+      var duration = responseReceived.ToDateTime() - requestSent.ToDateTime();
       data.Fields[DurationSecondsColumnName] = AresValueHelper.CreateNumber(duration.TotalSeconds);
     }
   }
@@ -334,6 +574,64 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     return $"{InputColumnPrefix}{parameter.Index}";
   }
 
+  private static bool TryCreatePlannerRecord(
+    PlannerTransaction transaction,
+    CampaignExecutionSummary summary,
+    IReadOnlyDictionary<string, int> experimentNumbers,
+    out PlannerRecord record)
+  {
+    var metadata = transaction.PlanningRequest?.Metadata;
+    if(!TryGetExperimentNumber(metadata, summary, experimentNumbers, transaction.TimeRequestSent, transaction.TimeResponseReceived, out var experimentNumber))
+    {
+      record = null!;
+      return false;
+    }
+
+    record = new PlannerRecord(transaction, experimentNumber);
+    return true;
+  }
+
+  private static bool TryCreateAnalyzerRecord(
+    AnalyzerTransaction transaction,
+    CampaignExecutionSummary summary,
+    IReadOnlyDictionary<string, int> experimentNumbers,
+    out AnalyzerRecord record)
+  {
+    var metadata = transaction.AnalysisRequest?.Metadata;
+    if(!TryGetExperimentNumber(metadata, summary, experimentNumbers, transaction.TimeRequestSent, transaction.TimeResponseReceived, out var experimentNumber))
+    {
+      record = null!;
+      return false;
+    }
+
+    record = new AnalyzerRecord(transaction, experimentNumber);
+    return true;
+  }
+
+  private static bool TryGetExperimentNumber(
+    RequestMetadata? metadata,
+    CampaignExecutionSummary summary,
+    IReadOnlyDictionary<string, int> experimentNumbers,
+    Timestamp? requestSent,
+    Timestamp? responseReceived,
+    out int experimentNumber)
+  {
+    experimentNumber = 0;
+    if(metadata is null ||
+      metadata.CampaignId != summary.CampaignId ||
+      !experimentNumbers.TryGetValue(metadata.ExperimentId, out experimentNumber))
+      return false;
+
+    var campaignStart = summary.ExecutionInfo?.TimeStarted;
+    var campaignEnd = summary.ExecutionInfo?.TimeFinished;
+    return campaignStart is not null &&
+      campaignEnd is not null &&
+      requestSent is not null &&
+      responseReceived is not null &&
+      requestSent.ToDateTime() >= campaignStart.ToDateTime() &&
+      responseReceived.ToDateTime() <= campaignEnd.ToDateTime();
+  }
+
   private record CommandRecord(
     ExperimentExecutionSummary Experiment,
     int ExperimentNumber,
@@ -341,4 +639,8 @@ public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _db
     int StepNumber,
     CommandExecutionSummary Command,
     int CommandNumber);
+
+  private record PlannerRecord(PlannerTransaction Transaction, int ExperimentNumber);
+
+  private record AnalyzerRecord(AnalyzerTransaction Transaction, int ExperimentNumber);
 }

--- a/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
+++ b/Ares.Core/DataManagement/DataMappers/CampaignDatasetGenerator.cs
@@ -5,13 +5,19 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Ares.Core.DataManagement.DataMappers;
 
-internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _dbContextFactory)
+public class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _dbContextFactory)
 {
   private const string ExperimentNumberColumnName = "Experiment Number";
+  private const string ExperimentExecutionIdColumnName = "Experiment Execution ID";
+  private const string ExperimentIdColumnName = "Experiment ID";
+  private const string ExperimentTemplateColumnName = "Experiment Template";
   private const string TimeStartedColumnName = "Time Started";
   private const string TimeFinishedColumnName = "Time Finished";
+  private const string DurationSecondsColumnName = "Duration Seconds";
   private const string AnalysisResultColumnName = "Analysis Result";
-  private const string ParameterColumnPrefix = "Parameter.";
+  private const string ResultOutputPathColumnName = "Result Output Path";
+  private const string InputColumnPrefix = "Input.";
+  private const string OutputColumnPrefix = "Output.";
 
   public async ValueTask<AresDataset[]> GenerateAsync(string summaryId, CancellationToken cancellationToken = default)
   {
@@ -28,7 +34,7 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
 
     var dataset = new AresDataset
     {
-      Name = GetDatasetName(summary, summaryId)
+      Name = "Experiments"
     };
 
     dataset.Columns.AddRange(CreateFixedColumns());
@@ -38,42 +44,29 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
     return [dataset];
   }
 
-  private static string GetDatasetName(CampaignExecutionSummary summary, string summaryId)
-  {
-    if(!string.IsNullOrWhiteSpace(summary.CampaignName))
-      return summary.CampaignName;
-
-    if(!string.IsNullOrWhiteSpace(summary.CampaignId))
-      return summary.CampaignId;
-
-    return summaryId;
-  }
-
   private static IEnumerable<AresDataColumn> CreateFixedColumns()
   {
     return
     [
-      new AresDataColumn
-      {
-        Name = ExperimentNumberColumnName,
-        Schema = new AresValueSchema { Type = AresDataType.Int }
-      },
-      new AresDataColumn
-      {
-        Name = TimeStartedColumnName,
-        Schema = new AresValueSchema { Type = AresDataType.Timestamp }
-      },
-      new AresDataColumn
-      {
-        Name = TimeFinishedColumnName,
-        Schema = new AresValueSchema { Type = AresDataType.Timestamp }
-      },
-      new AresDataColumn
-      {
-        Name = AnalysisResultColumnName,
-        Schema = new AresValueSchema { Type = AresDataType.Number, Optional = true }
-      }
+      CreateColumn(ExperimentNumberColumnName, AresDataType.Int),
+      CreateColumn(ExperimentExecutionIdColumnName, AresDataType.String, optional: true),
+      CreateColumn(ExperimentIdColumnName, AresDataType.String, optional: true),
+      CreateColumn(ExperimentTemplateColumnName, AresDataType.String, optional: true),
+      CreateColumn(TimeStartedColumnName, AresDataType.Timestamp, optional: true),
+      CreateColumn(TimeFinishedColumnName, AresDataType.Timestamp, optional: true),
+      CreateColumn(DurationSecondsColumnName, AresDataType.Number, optional: true),
+      CreateColumn(AnalysisResultColumnName, AresDataType.Number, optional: true),
+      CreateColumn(ResultOutputPathColumnName, AresDataType.String, optional: true)
     ];
+  }
+
+  private static AresDataColumn CreateColumn(string name, AresDataType type, bool optional = false)
+  {
+    return new AresDataColumn
+    {
+      Name = name,
+      Schema = new AresValueSchema { Type = type, Optional = optional }
+    };
   }
 
   private static IEnumerable<AresDataColumn> CreateDynamicColumns(IEnumerable<ExperimentExecutionSummary> experiments, CancellationToken cancellationToken)
@@ -89,7 +82,10 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
       foreach(var field in resultFields)
       {
         cancellationToken.ThrowIfCancellationRequested();
-        TryAddDynamicColumn(columns, field.Key, field.Value);
+        foreach(var flattenedField in AresValueFlattener.Flatten($"{OutputColumnPrefix}{field.Key}", field.Value))
+        {
+          TryAddDynamicColumn(columns, flattenedField.Key, flattenedField.Value);
+        }
       }
 
       var parameters = experiment.ExperimentOverview?.Parameters.OrderBy(GetParameterColumnName)
@@ -97,7 +93,14 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
       foreach(var parameter in parameters)
       {
         cancellationToken.ThrowIfCancellationRequested();
-        TryAddDynamicColumn(columns, GetParameterColumnName(parameter), parameter.GetValue());
+        var parameterValue = parameter.GetValue();
+        if(parameterValue is null)
+          continue;
+
+        foreach(var flattenedField in AresValueFlattener.Flatten(GetParameterColumnName(parameter), parameterValue))
+        {
+          TryAddDynamicColumn(columns, flattenedField.Key, flattenedField.Value);
+        }
       }
     }
 
@@ -110,12 +113,19 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
 
   private static void TryAddDynamicColumn(IDictionary<string, AresValueSchema> columns, string columnName, AresValue? value)
   {
-    if(value is null || columns.ContainsKey(columnName))
+    if(value is null)
       return;
 
     var schema = value.ToAresValueSchema();
     schema.Optional = true;
-    columns[columnName] = schema;
+    if(!columns.TryGetValue(columnName, out var existingSchema))
+    {
+      columns[columnName] = schema;
+      return;
+    }
+
+    if(existingSchema.Type != schema.Type)
+      existingSchema.Type = AresDataType.Any;
   }
 
   private static AresDataRow CreateRow(ExperimentExecutionSummary experiment, int experimentNumber, CancellationToken cancellationToken)
@@ -125,19 +135,31 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
     var data = new AresStruct();
     data.Fields[ExperimentNumberColumnName] = AresValueHelper.CreateInt(experimentNumber);
 
+    AddString(data, ExperimentExecutionIdColumnName, experiment.HasUniqueId ? experiment.UniqueId : null);
+    AddString(data, ExperimentIdColumnName, experiment.ExperimentId);
+    AddString(data, ExperimentTemplateColumnName, experiment.ExperimentOverview?.Template?.Name);
+
     if(experiment.ExecutionInfo?.TimeStarted is not null)
       data.Fields[TimeStartedColumnName] = AresValueHelper.CreateTimestamp(experiment.ExecutionInfo.TimeStarted);
 
     if(experiment.ExecutionInfo?.TimeFinished is not null)
       data.Fields[TimeFinishedColumnName] = AresValueHelper.CreateTimestamp(experiment.ExecutionInfo.TimeFinished);
 
+    if(experiment.ExecutionInfo?.TimeStarted is not null && experiment.ExecutionInfo.TimeFinished is not null)
+    {
+      var duration = experiment.ExecutionInfo.TimeFinished.ToDateTime() - experiment.ExecutionInfo.TimeStarted.ToDateTime();
+      data.Fields[DurationSecondsColumnName] = AresValueHelper.CreateNumber(duration.TotalSeconds);
+    }
+
     if(experiment.ExperimentOverview?.AnalysisOverview is not null)
       data.Fields[AnalysisResultColumnName] = AresValueHelper.CreateNumber(experiment.ExperimentOverview.AnalysisOverview.Result);
+
+    AddString(data, ResultOutputPathColumnName, experiment.ResultOutputPath);
 
     foreach(var field in experiment.ExperimentOverview?.Result?.Fields ?? [])
     {
       cancellationToken.ThrowIfCancellationRequested();
-      data.Fields[field.Key] = field.Value.Clone();
+      AddFlattenedValue(data, $"{OutputColumnPrefix}{field.Key}", field.Value, cancellationToken);
     }
 
     foreach(var parameter in experiment.ExperimentOverview?.Parameters ?? [])
@@ -146,7 +168,7 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
 
       var parameterValue = parameter.GetValue();
       if(parameterValue is not null)
-        data.Fields[GetParameterColumnName(parameter)] = parameterValue.Clone();
+        AddFlattenedValue(data, GetParameterColumnName(parameter), parameterValue, cancellationToken);
     }
 
     return new AresDataRow
@@ -155,14 +177,29 @@ internal class CampaignDatasetGenerator(IDbContextFactory<CoreDatabaseContext> _
     };
   }
 
+  private static void AddString(AresStruct data, string columnName, string? value)
+  {
+    if(!string.IsNullOrWhiteSpace(value))
+      data.Fields[columnName] = AresValueHelper.CreateString(value);
+  }
+
+  private static void AddFlattenedValue(AresStruct data, string columnName, AresValue value, CancellationToken cancellationToken)
+  {
+    foreach(var flattenedField in AresValueFlattener.Flatten(columnName, value))
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      data.Fields[flattenedField.Key] = flattenedField.Value.Clone();
+    }
+  }
+
   private static string GetParameterColumnName(Parameter parameter)
   {
     if(!string.IsNullOrWhiteSpace(parameter.Metadata?.Name))
-      return $"{ParameterColumnPrefix}{parameter.Metadata.Name}";
+      return $"{InputColumnPrefix}{parameter.Metadata.Name}";
 
     if(!string.IsNullOrWhiteSpace(parameter.UniqueId))
-      return $"{ParameterColumnPrefix}{parameter.UniqueId}";
+      return $"{InputColumnPrefix}{parameter.UniqueId}";
 
-    return $"{ParameterColumnPrefix}{parameter.Index}";
+    return $"{InputColumnPrefix}{parameter.Index}";
   }
 }

--- a/Ares.Core/DataManagement/DataMappers/DeviceStateDatasetGenerator.cs
+++ b/Ares.Core/DataManagement/DataMappers/DeviceStateDatasetGenerator.cs
@@ -39,7 +39,7 @@ public class DeviceStateDatasetGenerator(IDeviceStateGetter _deviceStateGetter)
   {
     var columns = states
       .SelectMany(state => state.Data?.Fields ?? [])
-      .SelectMany(field => FlattenField(field.Key, field.Value))
+      .SelectMany(field => AresValueFlattener.Flatten(GetColumnName(field.Key), field.Value))
       .GroupBy(field => field.Key)
       .OrderBy(group => group.Key)
       .Select(group => new AresDataColumn
@@ -106,7 +106,7 @@ public class DeviceStateDatasetGenerator(IDeviceStateGetter _deviceStateGetter)
     foreach(var field in state.Data?.Fields ?? [])
     {
       cancellationToken.ThrowIfCancellationRequested();
-      foreach(var flattenedField in FlattenField(field.Key, field.Value))
+      foreach(var flattenedField in AresValueFlattener.Flatten(GetColumnName(field.Key), field.Value))
       {
         cancellationToken.ThrowIfCancellationRequested();
         data.Fields[flattenedField.Key] = flattenedField.Value.Clone();
@@ -117,23 +117,6 @@ public class DeviceStateDatasetGenerator(IDeviceStateGetter _deviceStateGetter)
     {
       Data = data
     };
-  }
-
-  private static IEnumerable<KeyValuePair<string, AresValue>> FlattenField(string fieldName, AresValue value)
-  {
-    if(value.KindCase != AresValue.KindOneofCase.StructValue)
-    {
-      yield return KeyValuePair.Create(GetColumnName(fieldName), value);
-      yield break;
-    }
-
-    foreach(var childField in value.StructValue.Fields)
-    {
-      foreach(var flattenedChildField in FlattenField($"{fieldName}.{childField.Key}", childField.Value))
-      {
-        yield return flattenedChildField;
-      }
-    }
   }
 
   private static string GetColumnName(string fieldName)

--- a/Ares.Core/EntityConfigurations/Execution/Experiments/ExperimentOverviewEntityConfiguration.cs
+++ b/Ares.Core/EntityConfigurations/Execution/Experiments/ExperimentOverviewEntityConfiguration.cs
@@ -18,5 +18,6 @@ internal class ExperimentOverviewEntityConfiguration : AresEntityTypeBaseConfigu
 
     builder.Navigation(e => e.AnalysisOverview).AutoInclude();
     builder.Navigation(e => e.Parameters).AutoInclude();
+    builder.Navigation(e => e.Template).AutoInclude();
   }
 }

--- a/Ares.Core/Execution/Executors/ExecutorSummaryHelpers.cs
+++ b/Ares.Core/Execution/Executors/ExecutorSummaryHelpers.cs
@@ -57,6 +57,7 @@ internal static class ExecutorSummaryHelpers
       TemplateId = template.UniqueId,
       CommandDescription = template.Metadata.Description,
       CommandName = template.Metadata.Name,
+      StatusCode = deviceResult?.StatusCode ?? CommandStatusCode.StatusUnspecified
     };
 
     if(template.HasOutputVarName)

--- a/UI/Features/DataExplorer/CampaignDataExplorer.razor
+++ b/UI/Features/DataExplorer/CampaignDataExplorer.razor
@@ -1,5 +1,385 @@
-﻿<h3>CampaignDataExplorer</h3>
+@using Ares.Core.DataManagement.DataMappers
+@using Ares.Core.Grpc.Services
+@using Ares.Datamodel
+@using Ares.Services
+@using Google.Protobuf.WellKnownTypes
+@using Microsoft.JSInterop
+@using UI.Components.Formatting
+@implements IDisposable
+@inject AutomationService AutomationClient
+@inject CampaignDatasetGenerator DatasetGenerator
+@inject IJSRuntime JS
+
+<section class="campaign-data-explorer">
+  <div class="explorer-header">
+    <div>
+      <h3>Campaign Data Explorer</h3>
+      <p>Select a completed campaign execution to inspect and export its experiment data.</p>
+    </div>
+
+    <div class="data-summary" aria-label="Campaign data summary">
+      <div>
+        <span class="summary-value">@CampaignCount</span>
+        <span class="summary-label">Campaigns</span>
+      </div>
+      <div>
+        <span class="summary-value">@AppliedExperimentCount</span>
+        <span class="summary-label">Experiments</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="campaign-data-grid">
+    <aside class="campaign-panel" aria-label="Completed campaigns">
+      <div class="panel-toolbar">
+        <div>
+          <h4>Campaigns</h4>
+          <span>@FilteredCampaignCount shown</span>
+        </div>
+        <button type="button" class="clear-button" @onclick="ClearSelection" disabled="@(string.IsNullOrWhiteSpace(_selectedCampaignId) || _loadingDatasets)">
+          Clear
+        </button>
+      </div>
+
+      <label class="search-field">
+        <RadzenIcon Icon="search" />
+        <input type="search" placeholder="Filter campaigns" disabled="@_loadingDatasets" @bind="_filterText" @bind:event="oninput" />
+      </label>
+
+      @if (_campaigns is null)
+      {
+        <div class="empty-state compact">
+          <RadzenIcon Icon="hourglass_empty" />
+          <span>Loading campaigns...</span>
+        </div>
+      }
+      else if (!_campaigns.Any())
+      {
+        <div class="empty-state compact">
+          <RadzenIcon Icon="science" />
+          <span>No completed campaign data found.</span>
+        </div>
+      }
+      else if (!FilteredCampaigns.Any())
+      {
+        <div class="empty-state compact">
+          <RadzenIcon Icon="search_off" />
+          <span>No campaigns match this filter.</span>
+        </div>
+      }
+      else
+      {
+        <ul class="campaign-list">
+          @foreach (var campaign in FilteredCampaigns)
+          {
+            var isSelected = campaign.SummaryId == _selectedCampaignId;
+
+            <li class="@(isSelected ? "selected" : null)">
+              <button type="button" disabled="@_loadingDatasets" @onclick="() => SelectCampaign(campaign.SummaryId)">
+                <span class="campaign-marker" aria-hidden="true"></span>
+                <span class="campaign-text">
+                  <span class="campaign-name">@campaign.CampaignName</span>
+                  <span class="campaign-meta">@campaign.CompletionTimeDisplay</span>
+                  <span class="campaign-meta">@campaign.ExperimentCount experiment@(campaign.ExperimentCount == 1 ? string.Empty : "s")</span>
+                </span>
+              </button>
+            </li>
+          }
+        </ul>
+      }
+
+      <div class="selection-actions">
+        <button type="button" class="apply-button" @onclick="ApplySelectionAsync" disabled="@(!CanApply)">
+          Apply
+        </button>
+
+        @if (_loadingDatasets)
+        {
+          <button type="button" class="cancel-button" @onclick="CancelDatasetLoad" disabled="@_cancelingDatasetLoad">
+            @(_cancelingDatasetLoad ? "Canceling..." : "Cancel")
+          </button>
+        }
+      </div>
+    </aside>
+
+    <section class="data-panel" aria-label="Campaign experiment data">
+      @if (_loadingDatasets)
+      {
+        <div class="loading-status">
+          <RadzenProgressBarCircular Mode="ProgressBarMode.Indeterminate" Size="ProgressBarCircularSize.Small" ShowValue="false" />
+          <div>
+            <strong>@(_cancelingDatasetLoad ? "Canceling..." : "Generating campaign tables...")</strong>
+            <span>@(_hasApplied ? "Current results remain available until the new data is ready." : "Loading experiment data for the selected campaign.")</span>
+          </div>
+          <button type="button" class="cancel-button compact" @onclick="CancelDatasetLoad" disabled="@_cancelingDatasetLoad">
+            @(_cancelingDatasetLoad ? "Canceling..." : "Cancel")
+          </button>
+        </div>
+      }
+
+      @if (!string.IsNullOrWhiteSpace(_exportError))
+      {
+        <div class="export-error">
+          <RadzenIcon Icon="error" />
+          <span>@_exportError</span>
+        </div>
+      }
+
+      @if (!_hasApplied && string.IsNullOrWhiteSpace(_selectedCampaignId))
+      {
+        <div class="empty-state">
+          <RadzenIcon Icon="table_view" />
+          <h4>No campaign selected</h4>
+          <p>Choose a completed campaign execution and apply the selection.</p>
+        </div>
+      }
+      else if (_loadingDatasets && !_hasApplied)
+      {
+        <div class="empty-state">
+          <RadzenIcon Icon="hourglass_empty" />
+          <h4>Loading campaign data</h4>
+          <p>Generating experiment tables for the selected campaign.</p>
+        </div>
+      }
+      else if (!string.IsNullOrWhiteSpace(_datasetError))
+      {
+        <div class="empty-state error">
+          <RadzenIcon Icon="error" />
+          <h4>Unable to load data</h4>
+          <p>@_datasetError</p>
+        </div>
+      }
+      else if (!_hasApplied)
+      {
+        <div class="empty-state">
+          <RadzenIcon Icon="table_view" />
+          <h4>Apply selection to load data</h4>
+          <p>Use Apply to generate tables for the selected campaign.</p>
+        </div>
+      }
+      else if (_datasets is null || _datasets.Length == 0 || _datasets.All(dataset => dataset.Rows.Count == 0))
+      {
+        <div class="empty-state">
+          <RadzenIcon Icon="filter_alt_off" />
+          <h4>No campaign data found</h4>
+          <p>The selected campaign did not produce any experiment tables.</p>
+        </div>
+      }
+      else
+      {
+        <div class="data-panel-header">
+          <div>
+            <h4>@AppliedCampaignName</h4>
+            <span>@AppliedExperimentCount experiment@(AppliedExperimentCount == 1 ? string.Empty : "s") across @_datasets.Length table@(_datasets.Length == 1 ? string.Empty : "s")</span>
+          </div>
+          <div class="export-actions">
+            <button type="button" class="export-button" @onclick="ExportCurrentAsync" disabled="@(!CanExport)">
+              <RadzenIcon Icon="download" />
+              <span>Export Current</span>
+            </button>
+            <button type="button" class="export-button" @onclick="ExportAllAsync" disabled="@(!CanExport)">
+              <RadzenIcon Icon="folder_zip" />
+              <span>@(_exportingDatasets ? "Exporting..." : "Export All")</span>
+            </button>
+          </div>
+        </div>
+
+        <RadzenTabs Class="dataset-tabs" RenderMode="TabRenderMode.Server" @bind-SelectedIndex="_selectedDatasetTabIndex">
+          <Tabs>
+            @for (var index = 0; index < _datasets.Length; index++)
+            {
+              var dataset = _datasets[index];
+              <RadzenTabsItem Text="@GetTableName(index, dataset)">
+                <AresDatasetTable @key="dataset" Dataset="@dataset" />
+              </RadzenTabsItem>
+            }
+          </Tabs>
+        </RadzenTabs>
+      }
+    </section>
+  </div>
+</section>
 
 @code {
+  private List<CampaignDisplayItem>? _campaigns;
+  private AresDataset[]? _datasets;
+  private CancellationTokenSource? _datasetLoadCancellation;
+  private string? _filterText;
+  private string? _selectedCampaignId;
+  private string? _appliedCampaignId;
+  private string? _datasetError;
+  private string? _exportError;
+  private int _selectedDatasetTabIndex;
+  private bool _loadingDatasets;
+  private bool _cancelingDatasetLoad;
+  private bool _exportingDatasets;
+  private bool _hasApplied;
 
+  private int CampaignCount => _campaigns?.Count ?? 0;
+  private int FilteredCampaignCount => FilteredCampaigns.Count();
+  private int AppliedExperimentCount => AppliedCampaign?.ExperimentCount ?? 0;
+  private string AppliedCampaignName => AppliedCampaign?.CampaignName ?? "Campaign Data";
+  private CampaignDisplayItem? AppliedCampaign => _campaigns?.FirstOrDefault(campaign => campaign.SummaryId == _appliedCampaignId);
+  private bool CanApply => !string.IsNullOrWhiteSpace(_selectedCampaignId) && !_loadingDatasets && !_exportingDatasets;
+  private bool CanExport => !_loadingDatasets && !_exportingDatasets && _datasets?.Any(dataset => dataset.Rows.Count > 0) == true;
+
+  private IEnumerable<CampaignDisplayItem> FilteredCampaigns
+  {
+    get
+    {
+      if (_campaigns is null)
+        return Enumerable.Empty<CampaignDisplayItem>();
+
+      if (string.IsNullOrWhiteSpace(_filterText))
+        return _campaigns;
+
+      return _campaigns.Where(campaign =>
+        campaign.CampaignName.Contains(_filterText, StringComparison.OrdinalIgnoreCase) ||
+        campaign.SummaryId.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
+    }
+  }
+
+  protected override async Task OnInitializedAsync()
+  {
+    var response = await AutomationClient.GetAvailableCampaignExecutionSummaries(new Empty(), null);
+    _campaigns = response.AvailableCampaignSummaries
+      .Select(campaign => new CampaignDisplayItem(
+        campaign.SummaryId,
+        string.IsNullOrWhiteSpace(campaign.CampaignName) ? campaign.SummaryId : campaign.CampaignName,
+        campaign.CompletionTime.ToReadableTimestamp(),
+        campaign.CompletionTime.ToDateTime(),
+        (int)campaign.NumExperiments))
+      .OrderByDescending(campaign => campaign.CompletionTime)
+      .ToList();
+  }
+
+  private void SelectCampaign(string summaryId)
+  {
+    if (!_loadingDatasets)
+      _selectedCampaignId = summaryId;
+  }
+
+  private void ClearSelection()
+  {
+    if (!_loadingDatasets)
+      _selectedCampaignId = null;
+  }
+
+  private async Task ApplySelectionAsync()
+  {
+    if (!CanApply || _selectedCampaignId is null)
+      return;
+
+    _datasetLoadCancellation?.Cancel();
+    _datasetLoadCancellation?.Dispose();
+    _datasetLoadCancellation = new CancellationTokenSource();
+    var cancellationToken = _datasetLoadCancellation.Token;
+    var pendingCampaignId = _selectedCampaignId;
+
+    _loadingDatasets = true;
+    _cancelingDatasetLoad = false;
+    _datasetError = null;
+    _exportError = null;
+    StateHasChanged();
+    await Task.Yield();
+
+    try
+    {
+      var datasets = await Task.Run(
+        async () => await DatasetGenerator.GenerateAsync(pendingCampaignId, cancellationToken).ConfigureAwait(false),
+        cancellationToken);
+
+      cancellationToken.ThrowIfCancellationRequested();
+      _datasets = datasets;
+      _appliedCampaignId = pendingCampaignId;
+      _selectedDatasetTabIndex = 0;
+      _hasApplied = true;
+    }
+    catch (OperationCanceledException)
+    {
+      _datasetError = null;
+    }
+    catch (Exception ex)
+    {
+      _datasetError = ex.Message;
+    }
+    finally
+    {
+      _loadingDatasets = false;
+      _cancelingDatasetLoad = false;
+      await InvokeAsync(StateHasChanged);
+    }
+  }
+
+  private void CancelDatasetLoad()
+  {
+    if (!_loadingDatasets || _cancelingDatasetLoad)
+      return;
+
+    _cancelingDatasetLoad = true;
+    _datasetLoadCancellation?.Cancel();
+  }
+
+  private async Task ExportCurrentAsync()
+  {
+    if (!CanExport || _datasets is null)
+      return;
+
+    var index = Math.Clamp(_selectedDatasetTabIndex, 0, _datasets.Length - 1);
+    await ExportAsync(() => DatasetExportHelper.CreateCsv(_datasets[index], $"campaign-{GetExportCampaignName()}-{GetTableName(index, _datasets[index]).ToLowerInvariant()}"));
+  }
+
+  private async Task ExportAllAsync()
+  {
+    if (!CanExport || _datasets is null)
+      return;
+
+    await ExportAsync(() => DatasetExportHelper.CreateZip(_datasets, $"campaign-{GetExportCampaignName()}-all"));
+  }
+
+  private async Task ExportAsync(Func<DatasetExport> createExport)
+  {
+    _exportingDatasets = true;
+    _exportError = null;
+    await InvokeAsync(StateHasChanged);
+    await Task.Delay(50);
+
+    try
+    {
+      var export = await Task.Run(createExport);
+      await DatasetExportHelper.DownloadAsync(JS, export);
+    }
+    catch (Exception ex)
+    {
+      _exportError = $"Unable to export dataset: {ex.Message}";
+    }
+    finally
+    {
+      _exportingDatasets = false;
+      await InvokeAsync(StateHasChanged);
+    }
+  }
+
+  private string GetExportCampaignName()
+  {
+    return string.IsNullOrWhiteSpace(_appliedCampaignId) ? "data" : _appliedCampaignId;
+  }
+
+  private static string GetTableName(int index, AresDataset dataset)
+  {
+    return index == 0 ? "Experiments" : dataset.Name;
+  }
+
+  public void Dispose()
+  {
+    _datasetLoadCancellation?.Cancel();
+    _datasetLoadCancellation?.Dispose();
+  }
+
+  private record CampaignDisplayItem(
+    string SummaryId,
+    string CampaignName,
+    string CompletionTimeDisplay,
+    DateTime CompletionTime,
+    int ExperimentCount);
 }

--- a/UI/Features/DataExplorer/CampaignDataExplorer.razor
+++ b/UI/Features/DataExplorer/CampaignDataExplorer.razor
@@ -184,6 +184,17 @@
           </div>
         </div>
 
+        <div class="campaign-details" aria-label="Applied campaign details">
+          <div>
+            <span class="detail-label">Tags</span>
+            <span class="detail-value">@AppliedCampaignTags</span>
+          </div>
+          <div>
+            <span class="detail-label">Notes</span>
+            <span class="detail-value">@AppliedCampaignNotes</span>
+          </div>
+        </div>
+
         <RadzenTabs Class="dataset-tabs" RenderMode="TabRenderMode.Server" @bind-SelectedIndex="_selectedDatasetTabIndex">
           <Tabs>
             @for (var index = 0; index < _datasets.Length; index++)
@@ -219,6 +230,8 @@
   private int FilteredCampaignCount => FilteredCampaigns.Count();
   private int AppliedExperimentCount => AppliedCampaign?.ExperimentCount ?? 0;
   private string AppliedCampaignName => AppliedCampaign?.CampaignName ?? "Campaign Data";
+  private string AppliedCampaignTags => string.IsNullOrWhiteSpace(AppliedCampaign?.Tags) ? "No tags" : AppliedCampaign.Tags;
+  private string AppliedCampaignNotes => string.IsNullOrWhiteSpace(AppliedCampaign?.Notes) ? "No notes" : AppliedCampaign.Notes;
   private CampaignDisplayItem? AppliedCampaign => _campaigns?.FirstOrDefault(campaign => campaign.SummaryId == _appliedCampaignId);
   private bool CanApply => !string.IsNullOrWhiteSpace(_selectedCampaignId) && !_loadingDatasets && !_exportingDatasets;
   private bool CanExport => !_loadingDatasets && !_exportingDatasets && _datasets?.Any(dataset => dataset.Rows.Count > 0) == true;
@@ -235,20 +248,33 @@
 
       return _campaigns.Where(campaign =>
         campaign.CampaignName.Contains(_filterText, StringComparison.OrdinalIgnoreCase) ||
-        campaign.SummaryId.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
+        campaign.SummaryId.Contains(_filterText, StringComparison.OrdinalIgnoreCase) ||
+        campaign.Tags.Contains(_filterText, StringComparison.OrdinalIgnoreCase) ||
+        campaign.Notes.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
     }
   }
 
   protected override async Task OnInitializedAsync()
   {
     var response = await AutomationClient.GetAvailableCampaignExecutionSummaries(new Empty(), null);
-    _campaigns = response.AvailableCampaignSummaries
-      .Select(campaign => new CampaignDisplayItem(
-        campaign.SummaryId,
-        string.IsNullOrWhiteSpace(campaign.CampaignName) ? campaign.SummaryId : campaign.CampaignName,
-        campaign.CompletionTime.ToReadableTimestamp(),
-        campaign.CompletionTime.ToDateTime(),
-        (int)campaign.NumExperiments))
+    var campaigns = await Task.WhenAll(response.AvailableCampaignSummaries
+      .Select(async campaign =>
+      {
+        var summary = await AutomationClient.GetCampaignSummary(
+          new CampaignExecutionSummaryRequest { SummaryId = campaign.SummaryId },
+          null);
+
+        return new CampaignDisplayItem(
+          campaign.SummaryId,
+          string.IsNullOrWhiteSpace(campaign.CampaignName) ? campaign.SummaryId : campaign.CampaignName,
+          campaign.CompletionTime.ToReadableTimestamp(),
+          campaign.CompletionTime.ToDateTime(),
+          (int)campaign.NumExperiments,
+          summary.CampaignTags ?? string.Empty,
+          summary.CampaignNotes ?? string.Empty);
+      }));
+
+    _campaigns = campaigns
       .OrderByDescending(campaign => campaign.CompletionTime)
       .ToList();
   }
@@ -381,5 +407,7 @@
     string CampaignName,
     string CompletionTimeDisplay,
     DateTime CompletionTime,
-    int ExperimentCount);
+    int ExperimentCount,
+    string Tags,
+    string Notes);
 }

--- a/UI/Features/DataExplorer/CampaignDataExplorer.razor.css
+++ b/UI/Features/DataExplorer/CampaignDataExplorer.razor.css
@@ -1,0 +1,335 @@
+.campaign-data-explorer {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 0;
+  width: 100%;
+}
+
+.explorer-header,
+.data-summary,
+.panel-toolbar,
+.data-panel-header,
+.export-actions,
+.selection-actions,
+.loading-status,
+.export-error {
+  display: flex;
+}
+
+.explorer-header,
+.panel-toolbar,
+.data-panel-header {
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.explorer-header {
+  align-items: flex-start;
+  padding: 1rem 0 0.25rem;
+}
+
+.explorer-header h3,
+.explorer-header p,
+.panel-toolbar h4,
+.data-panel-header h4,
+.empty-state h4 {
+  margin: 0;
+}
+
+.explorer-header p {
+  margin-top: 0.35rem;
+  color: var(--rz-text-secondary-color, #667085);
+}
+
+.data-summary {
+  gap: 0.5rem;
+}
+
+.data-summary > div {
+  min-width: 6rem;
+  padding: 0.65rem 0.85rem;
+  border: var(--rz-card-border);
+  border-radius: 8px;
+  background: var(--rz-card-background-color);
+}
+
+.summary-value,
+.summary-label {
+  display: block;
+}
+
+.summary-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.summary-label {
+  margin-top: 0.15rem;
+  color: var(--rz-text-secondary-color, #667085);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.campaign-data-grid {
+  display: grid;
+  grid-template-columns: minmax(18rem, 24rem) minmax(0, 1fr);
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.campaign-panel,
+.data-panel {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  border: var(--rz-card-border);
+  border-radius: 8px;
+  background: var(--rz-card-background-color);
+  overflow: hidden;
+}
+
+.campaign-panel,
+.data-panel {
+  flex-direction: column;
+}
+
+.panel-toolbar,
+.data-panel-header {
+  flex: 0 0 auto;
+  padding: 0.9rem 1rem;
+  border-bottom: var(--rz-card-border);
+}
+
+.panel-toolbar span,
+.data-panel-header span,
+.campaign-meta,
+.loading-status span {
+  color: var(--rz-text-secondary-color, #667085);
+  font-size: 0.82rem;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.75rem 1rem;
+  padding: 0.55rem 0.7rem;
+  border: var(--rz-card-border);
+  border-radius: 7px;
+}
+
+.search-field input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.campaign-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 0;
+  margin: 0;
+  padding: 0 0.75rem 0.75rem;
+  overflow: auto;
+  list-style: none;
+}
+
+.campaign-list li {
+  border: 1px solid transparent;
+  border-radius: 8px;
+}
+
+.campaign-list li:hover {
+  background: var(--rz-secondary-lighter, #f2f4f7);
+}
+
+.campaign-list li.selected {
+  border-color: var(--rz-primary, #3b82f6);
+  background: color-mix(in srgb, var(--rz-primary, #3b82f6) 9%, transparent);
+}
+
+.campaign-list button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  width: 100%;
+  padding: 0.65rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.campaign-marker {
+  inline-size: 0.55rem;
+  block-size: 2.4rem;
+  border-radius: 999px;
+  background: var(--rz-info, #0ea5e9);
+}
+
+.campaign-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.campaign-name,
+.campaign-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.campaign-name {
+  font-weight: 600;
+}
+
+.selection-actions,
+.export-actions {
+  gap: 0.5rem;
+}
+
+.selection-actions {
+  flex: 0 0 auto;
+  padding: 0.75rem 1rem 1rem;
+  border-top: var(--rz-card-border);
+}
+
+.apply-button,
+.cancel-button,
+.clear-button,
+.export-button {
+  border: var(--rz-card-border);
+  border-radius: 6px;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.apply-button {
+  flex: 1;
+  padding: 0.65rem 0.85rem;
+  background: var(--rz-grid-apply-filter-button-background-color);
+  color: var(--rz-grid-apply-filter-button-color);
+}
+
+.cancel-button,
+.clear-button,
+.export-button {
+  background: transparent;
+  color: var(--rz-text-color, #344054);
+}
+
+.cancel-button {
+  padding: 0.65rem 0.85rem;
+}
+
+.cancel-button.compact,
+.clear-button,
+.export-button {
+  padding: 0.5rem 0.7rem;
+}
+
+.export-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+button:disabled {
+  color: var(--rz-text-disabled-color, #98a2b3);
+  cursor: default;
+}
+
+.loading-status,
+.export-error {
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: var(--rz-card-border);
+}
+
+.loading-status > div {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.export-error {
+  color: var(--rz-danger, #dc2626);
+}
+
+.empty-state {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 0;
+  padding: 2rem;
+  color: var(--rz-text-secondary-color, #667085);
+  text-align: center;
+}
+
+.empty-state p {
+  margin: 0;
+}
+
+.empty-state.compact {
+  min-height: 10rem;
+  padding: 1.25rem;
+}
+
+.empty-state.error h4 {
+  color: var(--rz-danger, #dc2626);
+}
+
+::deep .dataset-tabs {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+::deep .dataset-tabs > .rz-tabview-nav {
+  flex: 0 0 auto;
+}
+
+::deep .dataset-tabs > .rz-tabview-panels,
+::deep .dataset-tabs .rz-tabview-panel {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+@media (max-width: 900px) {
+  .explorer-header {
+    flex-direction: column;
+  }
+
+  .data-summary {
+    width: 100%;
+  }
+
+  .data-summary > div {
+    flex: 1;
+  }
+
+  .campaign-data-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/UI/Features/DataExplorer/CampaignDataExplorer.razor.css
+++ b/UI/Features/DataExplorer/CampaignDataExplorer.razor.css
@@ -271,6 +271,35 @@ button:disabled {
   color: var(--rz-danger, #dc2626);
 }
 
+.campaign-details {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) minmax(18rem, 2fr);
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  padding: 0.75rem 1rem;
+  border-bottom: var(--rz-card-border);
+  background: var(--rz-card-flat-background-color);
+}
+
+.campaign-details > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.detail-label {
+  color: var(--rz-text-secondary-color, #667085);
+  font-size: 0.75rem;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.detail-value {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .empty-state {
   display: flex;
   flex: 1;
@@ -330,6 +359,10 @@ button:disabled {
   }
 
   .campaign-data-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .campaign-details {
     grid-template-columns: 1fr;
   }
 }

--- a/UI/Features/DataExplorer/DatasetExportHelper.cs
+++ b/UI/Features/DataExplorer/DatasetExportHelper.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Ares.Core.DataManagement.DataMappers;
+using Ares.Datamodel;
+using Microsoft.JSInterop;
+
+namespace UI.Features.DataExplorer;
+
+public static class DatasetExportHelper
+{
+  public static DatasetExport CreateCsv(AresDataset dataset, string fileNamePrefix)
+  {
+    return new DatasetExport(
+      AresDatasetExporter.ExportCsv(dataset),
+      $"{fileNamePrefix}-{CreateTimestamp()}.csv");
+  }
+
+  public static DatasetExport CreateZip(IEnumerable<AresDataset> datasets, string fileNamePrefix)
+  {
+    return new DatasetExport(
+      AresDatasetExporter.ExportZip(datasets),
+      $"{fileNamePrefix}-{CreateTimestamp()}.zip");
+  }
+
+  public static async Task DownloadAsync(IJSRuntime js, DatasetExport export)
+  {
+    using(export.Stream)
+    using(var streamReference = new DotNetStreamReference(export.Stream))
+    {
+      await js.InvokeVoidAsync("downloadFileFromStream", export.FileName, streamReference);
+    }
+  }
+
+  private static string CreateTimestamp()
+  {
+    return DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+  }
+}
+
+public record DatasetExport(Stream Stream, string FileName);

--- a/UI/Features/DataExplorer/DeviceStateExplorer.razor
+++ b/UI/Features/DataExplorer/DeviceStateExplorer.razor
@@ -584,11 +584,7 @@
     {
       var export = await Task.Run(CreateCurrentExport);
 
-      using(export.Stream)
-      using(var streamReference = new DotNetStreamReference(export.Stream))
-      {
-        await JS.InvokeVoidAsync("downloadFileFromStream", export.FileName, streamReference);
-      }
+      await DatasetExportHelper.DownloadAsync(JS, export);
     }
     catch (Exception ex)
     {
@@ -603,19 +599,11 @@
 
   private DatasetExport CreateCurrentExport()
   {
-    var timestamp = DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
-
     return _appliedDisplayMode switch
     {
-      "Long" when _longDataset is not null => new DatasetExport(
-          AresDatasetExporter.ExportCsv(_longDataset),
-          $"device-state-long-{timestamp}.csv"),
-      "Wide" when _wideDataset is not null => new DatasetExport(
-          AresDatasetExporter.ExportCsv(_wideDataset),
-          $"device-state-wide-{timestamp}.csv"),
-      "Separate" when _deviceDatasets is not null => new DatasetExport(
-          AresDatasetExporter.ExportZip(_deviceDatasets),
-          $"device-state-separate-{timestamp}.zip"),
+      "Long" when _longDataset is not null => DatasetExportHelper.CreateCsv(_longDataset, "device-state-long"),
+      "Wide" when _wideDataset is not null => DatasetExportHelper.CreateCsv(_wideDataset, "device-state-wide"),
+      "Separate" when _deviceDatasets is not null => DatasetExportHelper.CreateZip(_deviceDatasets, "device-state-separate"),
       _ => throw new InvalidOperationException("The current display mode does not have exportable data.")
     };
   }
@@ -901,5 +889,4 @@
 
   private record ExperimentDisplayItem(string Id, string Name);
 
-  private record DatasetExport(Stream Stream, string FileName);
 }

--- a/UI/Features/Execution/ExecutionViewModel.cs
+++ b/UI/Features/Execution/ExecutionViewModel.cs
@@ -103,7 +103,9 @@ public partial class ExecutionViewModel : ReactiveObject, INotifyPropertyChanged
     PlannerAdapterInfos = CampaignTemplate.ExperimentTemplate.GetAllPlannedParameters()
     .Select(parameter => parameter.GetPlanningMetadata())
     .Select(metadata => CampaignTemplate.PlannerAllocations
-    .FirstOrDefault(allocation => allocation.Parameter.Equals(metadata))?.Planner).ToHashSet();
+    .FirstOrDefault(allocation => allocation.Parameter.Equals(metadata))?.Planner)
+    .Where(info => info is not null)
+    .ToHashSet();
 
     var analyzerId = CampaignTemplate.ExperimentTemplate.AnalyzerId;
 


### PR DESCRIPTION
Added a separate viewer for campaign related data viewing/exporting. It includes general experiment data, command info, planner/analyzer transactions.